### PR TITLE
Fix documentation on prometheus endpoint security configuration

### DIFF
--- a/src/main/docs/guide/metricsConcepts.adoc
+++ b/src/main/docs/guide/metricsConcepts.adoc
@@ -325,6 +325,9 @@ You can configure this reporter using `micronaut.metrics.export.prometheus`.  Th
 .Example Prometheus Config
 [source,yml]
 ----
+endpoints:
+  prometheus:
+    sensitive: false
 micronaut:
   metrics:
     enabled: true


### PR DESCRIPTION
Without endpoints.prometheus.sensitive set to false, and following the given example configuration, prometheus metrics endpoint returns 401.