### PR TITLE
Fix WebMetricsPublisher root route path sanitization

### DIFF
--- a/micrometer-core/src/main/java/io/micronaut/configuration/metrics/binder/web/WebMetricsPublisher.java
+++ b/micrometer-core/src/main/java/io/micronaut/configuration/metrics/binder/web/WebMetricsPublisher.java
@@ -250,7 +250,7 @@ public class WebMetricsPublisher<T extends HttpResponse<?>> implements Publisher
      */
     private static String sanitizePath(String path) {
         if (!StringUtils.isEmpty(path)) {
-            return path
+            path = path
                     .replaceAll("//+", "/")
                     .replaceAll("/$", "");
         }

--- a/micrometer-core/src/test/groovy/io/micronaut/configuration/metrics/binder/web/HttpMetricsSpec.groovy
+++ b/micrometer-core/src/test/groovy/io/micronaut/configuration/metrics/binder/web/HttpMetricsSpec.groovy
@@ -54,6 +54,13 @@ class HttpMetricsSpec extends Specification {
         serverTimer.count() == 1
         clientTimer.count() == 1
 
+        when:"A request is sent to the root route"
+
+        then:
+        client.root() == 'root'
+        registry.get(WebMetricsPublisher.METRIC_HTTP_CLIENT_REQUESTS).tags('uri','root').timer()
+        registry.get(WebMetricsPublisher.METRIC_HTTP_SERVER_REQUESTS).tags('uri','root').timer()
+
         when:"A request is sent with a uri template"
         def result = client.template("foo")
 
@@ -106,31 +113,39 @@ class HttpMetricsSpec extends Specification {
 
 
 
-    @Client('/test-http-metrics')
+    @Client('/')
     static interface TestClient {
         @Get
+        String root()
+
+        @Get('/test-http-metrics')
         String index()
 
-        @Get("/{id}")
+        @Get("/test-http-metrics/{id}")
         String template(String id)
 
-        @Get("/error")
+        @Get("/test-http-metrics/error")
         HttpResponse error()
     }
 
-    @Controller('/test-http-metrics')
+    @Controller('/')
     static class TestController {
         @Get
+        String root() {
+            return "root"
+        }
+
+        @Get('/test-http-metrics')
         String index() {
             return "ok"
         }
 
-        @Get("/{id}")
+        @Get("/test-http-metrics/{id}")
         String template(String id) {
             return "ok " + id
         }
 
-        @Get("/error")
+        @Get("/test-http-metrics/error")
         HttpResponse error() {
             HttpResponse.status(HttpStatus.CONFLICT)
         }


### PR DESCRIPTION
Requests to the root route are being incorrectly recorded with an empty `uri` rather than the intended value of `root`, because the path isn't being check for emptiness after the first set of replacements.