### PR TITLE
Remove reference to non-existing Control Property for web binder

### DIFF
--- a/src/main/docs/guide/metricsConcepts.adoc
+++ b/src/main/docs/guide/metricsConcepts.adoc
@@ -83,8 +83,6 @@ There is a default web filter provided for web metrics.  All routes, status code
 .Filter Path
 If enabled, be default the path `/**` will be intercepted.  If you wish to change which paths are run through the filter for the server set `micronaut.metrics.http.path`. For the client set `micronaut.metrics.http.client.path`.
 
-*Control Property*: `micronaut.metrics.web.enabled`
-
 .Metrics provided
 |=======
 |*Name*


### PR DESCRIPTION
It seems that `micronaut.metrics.web.enabled` does not exist (I googled it and I also looked in the source code).
So I removed the reference to it, since it would duplicate line 81.