### PR TITLE
Fix Metric Configurer Example

### DIFF
--- a/micrometer-core/src/test/groovy/io/micronaut/docs/SimpleMeterRegistryConfigurer.java
+++ b/micrometer-core/src/test/groovy/io/micronaut/docs/SimpleMeterRegistryConfigurer.java
@@ -18,7 +18,9 @@ package io.micronaut.docs;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import io.micronaut.configuration.metrics.aggregator.MeterRegistryConfigurer;
+import javax.inject.Singleton;
 
+@Singleton
 public class SimpleMeterRegistryConfigurer implements MeterRegistryConfigurer {
 
     @Override


### PR DESCRIPTION
I tried this example as it was described but the metric registry was not configured, so I added the @singleton and it worked. It seems that the example is missing this annotation.