### PR TITLE
Remove non-existing control property

### DIFF
--- a/src/main/docs/guide/metricsConcepts.adoc
+++ b/src/main/docs/guide/metricsConcepts.adoc
@@ -83,8 +83,6 @@ There is a default web filter provided for web metrics.  All routes, status code
 .Filter Path
 If enabled, be default the path `/**` will be intercepted.  If you wish to change which paths are run through the filter for the server set `micronaut.metrics.http.path`. For the client set `micronaut.metrics.http.client.path`.
 
-*Control Property*: `micronaut.metrics.web.enabled`
-
 .Metrics provided
 |=======
 |*Name*


### PR DESCRIPTION
I looked in the source code and researching in the internet and it seems that the control property `micronaut.metrics.web.enabled` is ignored. So I am deleting it from the documentation.