### PR TITLE
Add a feature toggle to enabled histograms in web metrics

### DIFF
--- a/micrometer-core/src/main/java/io/micronaut/configuration/metrics/binder/web/ClientRequestMetricRegistryFilter.java
+++ b/micrometer-core/src/main/java/io/micronaut/configuration/metrics/binder/web/ClientRequestMetricRegistryFilter.java
@@ -18,6 +18,7 @@ package io.micronaut.configuration.metrics.binder.web;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micronaut.configuration.metrics.annotation.RequiresMetrics;
 import io.micronaut.context.annotation.Requires;
+import io.micronaut.context.annotation.Value;
 import io.micronaut.core.util.StringUtils;
 import io.micronaut.http.HttpAttributes;
 import io.micronaut.http.HttpResponse;
@@ -29,6 +30,9 @@ import org.reactivestreams.Publisher;
 
 import java.util.Optional;
 
+import static io.micronaut.configuration.metrics.binder.web.WebMetricsPublisher.USE_HISTOGRAM;
+import static io.micronaut.configuration.metrics.micrometer.MeterRegistryFactory.MICRONAUT_METRICS_BINDERS;
+
 /**
  * A {@link HttpClientFilter} that produces metrics under the key {@code http.client.requests}.
  *
@@ -39,8 +43,13 @@ import java.util.Optional;
 @RequiresMetrics
 @Requires(property = WebMetricsPublisher.ENABLED, notEquals = StringUtils.FALSE)
 public class ClientRequestMetricRegistryFilter implements HttpClientFilter {
+
     private final String HOST_HEADER = "host";
     private final MeterRegistry meterRegistry;
+
+    private final String USE_HISTOGRAM_VALUE_STRING = "${" + USE_HISTOGRAM + ":false}";
+    @Value(USE_HISTOGRAM_VALUE_STRING)
+    private boolean useHistogram;
 
     /**
      * Default constructor.
@@ -63,7 +72,8 @@ public class ClientRequestMetricRegistryFilter implements HttpClientFilter {
                 start,
                 request.getMethod().toString(),
                 false,
-                resolveHost(request)
+                resolveHost(request),
+                useHistogram
         );
     }
 

--- a/micrometer-core/src/main/java/io/micronaut/configuration/metrics/binder/web/ServerRequestMeterRegistryFilter.java
+++ b/micrometer-core/src/main/java/io/micronaut/configuration/metrics/binder/web/ServerRequestMeterRegistryFilter.java
@@ -18,6 +18,7 @@ package io.micronaut.configuration.metrics.binder.web;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micronaut.configuration.metrics.annotation.RequiresMetrics;
 import io.micronaut.context.annotation.Requires;
+import io.micronaut.context.annotation.Value;
 import io.micronaut.core.util.StringUtils;
 import io.micronaut.http.HttpAttributes;
 import io.micronaut.http.HttpRequest;
@@ -28,6 +29,8 @@ import io.micronaut.http.filter.ServerFilterChain;
 import org.reactivestreams.Publisher;
 
 import java.util.Optional;
+
+import static io.micronaut.configuration.metrics.binder.web.WebMetricsPublisher.USE_HISTOGRAM;
 
 /**
  * Once per request web filter that will register the timers
@@ -47,6 +50,11 @@ import java.util.Optional;
 public class ServerRequestMeterRegistryFilter extends OncePerRequestHttpServerFilter {
 
     private final MeterRegistry meterRegistry;
+
+    private final String USE_HISTOGRAM_VALUE_STRING = "${" + USE_HISTOGRAM + ":false}";
+    @Value(USE_HISTOGRAM_VALUE_STRING)
+    private boolean useHistogram;
+
 
     /**
      * Filter constructor.
@@ -74,7 +82,9 @@ public class ServerRequestMeterRegistryFilter extends OncePerRequestHttpServerFi
                 meterRegistry,
                 path,
                 start,
-                httpRequest.getMethod().toString()
+                httpRequest.getMethod().toString(),
+                true,
+                useHistogram
         );
     }
 

--- a/micrometer-core/src/test/groovy/io/micronaut/configuration/metrics/binder/web/HttpMetricsSpec.groovy
+++ b/micrometer-core/src/test/groovy/io/micronaut/configuration/metrics/binder/web/HttpMetricsSpec.groovy
@@ -111,9 +111,8 @@ class HttpMetricsSpec extends Specification {
         MICRONAUT_METRICS_ENABLED     | false
         (WebMetricsPublisher.ENABLED) | true
         (WebMetricsPublisher.ENABLED) | false
+        WebMetricsPublisher.USE_HISTOGRAM | true
     }
-
-
 
     @Client('/')
     static interface TestClient {


### PR DESCRIPTION
I enabled the web metrics in my project, but I had a huge problem that the metrics are not separated in buckets, so I cannot extract quantiles our of it. It makes measuring latencies less meaningful.
This PR creates a new configuration key (...web.use.histogram) which defaults to false. If it is set to true, this enables histograms in the timer metrics.