### PR TITLE
Incorrect groupId for prometheus registry dependency

### DIFF
--- a/src/main/docs/guide/metricsAndReporters/metricsAndReportersPrometheus.adoc
+++ b/src/main/docs/guide/metricsAndReporters/metricsAndReportersPrometheus.adoc
@@ -1,6 +1,6 @@
 You can include the Prometheus reporter via `io.micronaut.configuration:micronaut-micrometer-registry-prometheus:${micronaut.version}`
 
-dependency:micronaut-micrometer-registry-prometheus[groupId="io.micronaut.micrometer"]
+dependency:micronaut-micrometer-registry-prometheus[groupId="io.micronaut.configuration"]
 
 You can configure this reporter using `micronaut.metrics.export.prometheus`.  The most commonly changed configuration properties are listed below, but see https://github.com/micrometer-metrics/micrometer/blob/master/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheus/PrometheusConfig.java[PrometheusConfig] for more options
 


### PR DESCRIPTION
Updated incorrect dependency information from `groupId="io.micronaut.micrometer"` -> `groupId="io.micronaut.configuration"`