### PR TITLE
Added support for the metrics API of new relic. 

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -12,6 +12,7 @@ githubSlug=micronaut-projects/micronaut-micrometer
 developers=Graeme Rocher
 
 micrometerVersion=1.6.3
+newRelicMicrometerRegistryVersion=0.6.0
 validationVersion=2.0.1.Final
 jcacheVersion=1.1.1
 

--- a/micrometer-registry-new-relic/build.gradle
+++ b/micrometer-registry-new-relic/build.gradle
@@ -8,6 +8,7 @@ dependencies {
     api project(":micrometer-core")
     api "javax.validation:validation-api:$validationVersion"
     api "io.micrometer:micrometer-registry-new-relic:$micrometerVersion"
+    api "com.newrelic.telemetry:micrometer-registry-new-relic:$newRelicMicrometerRegistryVersion"
 
     testImplementation "io.micronaut:micronaut-management"
     testImplementation "io.micronaut:micronaut-inject-groovy"

--- a/micrometer-registry-new-relic/src/main/java/io/micronaut/configuration/metrics/micrometer/newrelic/MicronautNewRelicRegistryConfig.java
+++ b/micrometer-registry-new-relic/src/main/java/io/micronaut/configuration/metrics/micrometer/newrelic/MicronautNewRelicRegistryConfig.java
@@ -1,0 +1,66 @@
+package io.micronaut.configuration.metrics.micrometer.newrelic;
+
+import com.newrelic.telemetry.micrometer.NewRelicRegistryConfig;
+import io.micrometer.core.instrument.config.validate.InvalidReason;
+
+import io.micrometer.core.lang.Nullable;
+
+import javax.inject.Singleton;
+
+import static io.micrometer.core.instrument.config.validate.PropertyValidator.getSecret;
+import static io.micrometer.core.instrument.config.validate.PropertyValidator.getString;
+import static io.micrometer.core.instrument.config.validate.PropertyValidator.getUrlString;
+import static io.micrometer.core.instrument.util.StringUtils.isBlank;
+
+/**
+ * Configuration for {@link NewRelicRegistry}.
+ *
+ */
+@Singleton
+public interface MicronautNewRelicRegistryConfig extends NewRelicRegistryConfig {
+
+    @Override
+    default String prefix() {
+        return "newrelic";
+    }
+
+    @Nullable
+    default String apiKey() {
+        return getSecret(this, "apiKey")
+                .invalidateWhen(
+                        secret -> isBlank(secret),
+                        "is required when publishing to Metrics API",
+                        InvalidReason.MISSING
+                )
+                .orElse(null);
+    }
+
+    /**
+     * @return The URI for the New Relic metric API. Only necessary if you need to override the
+     *     default URI (https://metric-api.newrelic.com/metric/v1).
+     */
+    default String uri() {
+        return getUrlString(this, "uri").orElse(null);
+    }
+
+    /**
+     * Return the service name which this registry will report as. Maps to the "service.name"
+     * attribute on the metrics.
+     *
+     * @return The Service Name.
+     */
+    default String serviceName() {
+        return getString(this, "serviceName").orElse(null);
+    }
+
+    /**
+     * Turn on "audit mode" in the underlying New Relic Telemetry SDK. This will log all data sent to
+     * the New Relic APIs. Be aware that if there is sensitive information in the data being sent that
+     * it will be sent to wherever the Telemetry SDK logs are configured to go.
+     *
+     * @return true if audit mode should be enabled.
+     */
+    default boolean enableAuditMode() {
+        return false;
+    }
+}


### PR DESCRIPTION
With this added, it offers the possibility to send micrometer data to the metrics API instead of the generic insights API. 
This give the users out of the box dashboards and also registers a service in new relic.

I don't like the switch between this implementation and the current one. The new property of NEWRELIC_METRIC_API
If someone has suggestions, please share. 

The library used : [link](https://github.com/newrelic/micrometer-registry-newrelic)
Implementation based on Spring Config example: [link](https://github.com/newrelic/micrometer-registry-newrelic/wiki/Spring-Config-Example)