### PR TITLE
Fixes #214 - make sure that CompositeMeterRegistry is closed

### DIFF
--- a/micrometer-core/src/main/java/io/micronaut/configuration/metrics/micrometer/MeterRegistryFactory.java
+++ b/micrometer-core/src/main/java/io/micronaut/configuration/metrics/micrometer/MeterRegistryFactory.java
@@ -23,6 +23,7 @@ import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import io.micronaut.configuration.metrics.aggregator.MeterRegistryConfigurer;
 import io.micronaut.configuration.metrics.aggregator.MicrometerMeterRegistryConfigurer;
 import io.micronaut.configuration.metrics.annotation.RequiresMetrics;
+import io.micronaut.context.annotation.Bean;
 import io.micronaut.context.annotation.Factory;
 import io.micronaut.context.annotation.Primary;
 import io.micronaut.core.annotation.TypeHint;
@@ -56,6 +57,7 @@ public class MeterRegistryFactory {
      */
     @Primary
     @Singleton
+    @Bean(preDestroy = "close")
     CompositeMeterRegistry compositeMeterRegistry(List<MeterRegistry> registries,
                                                   List<MeterRegistryConfigurer> configurers) {
         CompositeMeterRegistry compositeMeterRegistry = new CompositeMeterRegistry();


### PR DESCRIPTION
Make sure that `CompositeMeterRegistry#close` is called before being destroyed. This will internally call `close` on all configured `MeterRegistry` instances.