### PR TITLE
Upgrade micrometer to 1.7.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,6 +9,11 @@ buildscript {
 
 subprojects { Project subproject ->
     group "io.micronaut.micrometer"
+    repositories {
+        maven {
+            url 'https://repo.spring.io/milestone'
+        }
+    }
 
     if (subproject.name != 'micrometer-bom') {
         apply plugin: "io.micronaut.build.internal.common"

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,7 +11,7 @@ projectUrl=http://micronaut.io
 githubSlug=micronaut-projects/micronaut-micrometer
 developers=Graeme Rocher
 
-micrometerVersion=1.6.3
+micrometerVersion=1.7.0-M1
 validationVersion=2.0.1.Final
 jcacheVersion=1.1.1
 newRelicRegistryVersion=0.6.0


### PR DESCRIPTION
This is a first PR to upgrade micrometer to 1.7.0. It is still not released officially, so we are using 1.7.0-M1.

This should not be merged until 1.7.0 is released officially.