### PR TITLE
Use Reactor as implementation detail and fix tests

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 projectVersion=4.0.0-SNAPSHOT
 micronautDocsVersion=2.0.0.RC1
-micronautVersion=2.5.7
+micronautVersion=2.5.9
 micronautTestVersion=2.3.3
 groovyVersion=3.0.8
 spockVersion=2.0-groovy

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 projectVersion=4.0.0-SNAPSHOT
 micronautDocsVersion=2.0.0.RC1
-micronautVersion=2.5.9
+micronautVersion=3.0.0-M4
 micronautTestVersion=2.3.3
 groovyVersion=3.0.8
 spockVersion=2.0-groovy

--- a/micrometer-annotation/src/test/groovy/io/micronaut/micrometer/annotation/processing/GroovyAnnotationMappingSpec.groovy
+++ b/micrometer-annotation/src/test/groovy/io/micronaut/micrometer/annotation/processing/GroovyAnnotationMappingSpec.groovy
@@ -1,9 +1,9 @@
 package io.micronaut.micrometer.annotation.processing
 
+import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
 import io.micronaut.aop.Intercepted
-import io.micronaut.ast.transform.test.AbstractBeanDefinitionSpec
 
-class GroovyAnnotationMappingSpec extends AbstractBeanDefinitionSpec {
+class GroovyAnnotationMappingSpec extends AbstractTypeElementSpec {
 
     void 'test map timedset annotation'() {
         given:

--- a/micrometer-core/build.gradle
+++ b/micrometer-core/build.gradle
@@ -1,15 +1,3 @@
-configurations {
-    all {
-        resolutionStrategy {
-            eachDependency { DependencyResolveDetails details ->
-                if (details.requested.group == 'io.micronaut.cache') {
-                    details.useVersion '3.0.0.RC1'
-                }
-            }
-        }
-    }
-}
-
 dependencies {
     annotationProcessor "io.micronaut:micronaut-inject-java"
     annotationProcessor "io.micronaut:micronaut-graal"

--- a/micrometer-core/build.gradle
+++ b/micrometer-core/build.gradle
@@ -5,7 +5,7 @@ dependencies {
 
     api "io.micrometer:micrometer-core:$micrometerVersion"
     api "io.micronaut:micronaut-inject:$micronautVersion"
-    api "io.micronaut.reactor:micronaut-reactor"
+    implementation "io.projectreactor:reactor-core"
     compileOnly "io.micronaut:micronaut-management"
     compileOnly "io.micronaut.sql:micronaut-jdbc"
     compileOnly 'io.micronaut.cache:micronaut-cache-core'

--- a/micrometer-core/build.gradle
+++ b/micrometer-core/build.gradle
@@ -1,3 +1,15 @@
+configurations {
+    all {
+        resolutionStrategy {
+            eachDependency { DependencyResolveDetails details ->
+                if (details.requested.group == 'io.micronaut.cache') {
+                    details.useVersion '3.0.0.RC1'
+                }
+            }
+        }
+    }
+}
+
 dependencies {
     annotationProcessor "io.micronaut:micronaut-inject-java"
     annotationProcessor "io.micronaut:micronaut-graal"

--- a/micrometer-core/src/test/groovy/io/micronaut/configuration/metrics/management/endpoint/MetricsEndpointSpec.groovy
+++ b/micrometer-core/src/test/groovy/io/micronaut/configuration/metrics/management/endpoint/MetricsEndpointSpec.groovy
@@ -20,7 +20,7 @@ import io.micrometer.core.instrument.composite.CompositeMeterRegistry
 import io.micronaut.context.ApplicationContext
 import io.micronaut.http.HttpRequest
 import io.micronaut.http.HttpStatus
-import io.micronaut.http.client.RxHttpClient
+import io.micronaut.http.client.HttpClient
 import io.micronaut.http.client.exceptions.HttpClientResponseException
 import io.micronaut.runtime.server.EmbeddedServer
 import spock.lang.IgnoreIf
@@ -61,16 +61,16 @@ class MetricsEndpointSpec extends Specification {
         !context.containsBean(CompositeMeterRegistry)
 
         URL server = embeddedServer.getURL()
-        RxHttpClient rxClient = embeddedServer.applicationContext.createBean(RxHttpClient, server)
+        HttpClient client = embeddedServer.applicationContext.createBean(HttpClient, server)
 
         when:
-        rxClient.retrieve(HttpRequest.GET("/metrics"), Map).blockingFirst()
+        client.toBlocking().retrieve(HttpRequest.GET("/metrics"), Map).blockingFirst()
 
         then:
         thrown(HttpClientResponseException)
 
         cleanup:
-        rxClient.close()
+        client.close()
         embeddedServer.close()
     }
 
@@ -87,10 +87,10 @@ class MetricsEndpointSpec extends Specification {
                 "micronaut.metrics.binders.files.enabled"    : filesEnabled
         ])
         URL server = embeddedServer.getURL()
-        RxHttpClient rxClient = embeddedServer.applicationContext.createBean(RxHttpClient, server)
+        HttpClient client = embeddedServer.applicationContext.createBean(HttpClient, server)
 
         when:
-        def response = rxClient.exchange("/metrics", Map).blockingFirst()
+        def response = client.toBlocking().exchange("/metrics", Map)
         Map result = response.body()
 
         then:
@@ -129,7 +129,7 @@ class MetricsEndpointSpec extends Specification {
         }
 
         cleanup:
-        rxClient.close()
+        client.close()
         embeddedServer.close()
 
         where:
@@ -152,10 +152,10 @@ class MetricsEndpointSpec extends Specification {
                 "micronaut.metrics.binders.jvm.enabled": true
         ])
         URL server = embeddedServer.getURL()
-        RxHttpClient rxClient = embeddedServer.applicationContext.createBean(RxHttpClient, server)
+        HttpClient client = embeddedServer.applicationContext.createBean(HttpClient, server)
 
         when:
-        def response = rxClient.exchange("/metrics/$name", Map).blockingFirst()
+        def response = client.toBlocking().exchange("/metrics/$name", Map)
         Map result = response.body() as Map
 
         then:
@@ -165,7 +165,7 @@ class MetricsEndpointSpec extends Specification {
         result["baseUnit"]
 
         cleanup:
-        rxClient.close()
+        client.close()
         embeddedServer.close()
 
         where:
@@ -197,10 +197,10 @@ class MetricsEndpointSpec extends Specification {
                 "micronaut.metrics.binders.jvm.enabled": true
         ])
         URL server = embeddedServer.getURL()
-        RxHttpClient rxClient = embeddedServer.applicationContext.createBean(RxHttpClient, server)
+        HttpClient client = embeddedServer.applicationContext.createBean(HttpClient, server)
 
         when:
-        def response = rxClient.exchange("/metrics/jvm.buffer.count?tag=id:direct", Map).blockingFirst()
+        def response = client.toBlocking().exchange("/metrics/jvm.buffer.count?tag=id:direct", Map)
         Map result = response.body() as Map
 
         then:
@@ -210,14 +210,14 @@ class MetricsEndpointSpec extends Specification {
         result["baseUnit"]
 
         when:
-        rxClient.exchange("/metrics/jvm.buffer.count?tag=id:blah", Map).blockingFirst()
+        client.toBlocking().exchange("/metrics/jvm.buffer.count?tag=id:blah", Map)
 
         then:
         def e = thrown(HttpClientResponseException)
         e.status == HttpStatus.NOT_FOUND
 
         cleanup:
-        rxClient.close()
+        client.close()
         embeddedServer.close()
 
     }
@@ -231,16 +231,16 @@ class MetricsEndpointSpec extends Specification {
                 "micronaut.metrics.binders.jvm.enabled": true
         ])
         URL server = embeddedServer.getURL()
-        RxHttpClient rxClient = embeddedServer.applicationContext.createBean(RxHttpClient, server)
+        HttpClient client = embeddedServer.applicationContext.createBean(HttpClient, server)
 
         when:
-        rxClient.exchange("/metrics/$name", Map).blockingFirst()
+        client.toBlocking().exchange("/metrics/$name", Map)
 
         then:
         thrown(HttpClientResponseException)
 
         cleanup:
-        rxClient.close()
+        client.close()
         embeddedServer.close()
 
         where:
@@ -272,10 +272,10 @@ class MetricsEndpointSpec extends Specification {
                 "micronaut.metrics.binders.logback.enabled": true
         ])
         URL server = embeddedServer.getURL()
-        RxHttpClient rxClient = embeddedServer.applicationContext.createBean(RxHttpClient, server)
+        HttpClient client = embeddedServer.applicationContext.createBean(HttpClient, server)
 
         when:
-        def response = rxClient.exchange("/metrics/$name", Map).blockingFirst()
+        def response = client.toBlocking().exchange("/metrics/$name", Map)
         Map result = response.body() as Map
 
         then:
@@ -285,7 +285,7 @@ class MetricsEndpointSpec extends Specification {
         result["baseUnit"]
 
         cleanup:
-        rxClient.close()
+        client.close()
         embeddedServer.close()
 
         where:
@@ -301,16 +301,16 @@ class MetricsEndpointSpec extends Specification {
                 "micronaut.metrics.binders.logback.enabled": false
         ])
         URL server = embeddedServer.getURL()
-        RxHttpClient rxClient = embeddedServer.applicationContext.createBean(RxHttpClient, server)
+        HttpClient client = embeddedServer.applicationContext.createBean(HttpClient, server)
 
         when:
-        rxClient.exchange("/metrics/$name", Map).blockingFirst()
+        client.toBlocking().exchange("/metrics/$name", Map)
 
         then:
         thrown(HttpClientResponseException)
 
         cleanup:
-        rxClient.close()
+        client.close()
         embeddedServer.close()
 
         where:
@@ -326,10 +326,10 @@ class MetricsEndpointSpec extends Specification {
                 "micronaut.metrics.binders.uptime.enabled": true
         ])
         URL server = embeddedServer.getURL()
-        RxHttpClient rxClient = embeddedServer.applicationContext.createBean(RxHttpClient, server)
+        HttpClient client = embeddedServer.applicationContext.createBean(HttpClient, server)
 
         when:
-        def response = rxClient.exchange("/metrics/$name", Map).blockingFirst()
+        def response = client.toBlocking().exchange("/metrics/$name", Map)
         Map result = response.body() as Map
 
         then:
@@ -338,7 +338,7 @@ class MetricsEndpointSpec extends Specification {
         result["description"]
 
         cleanup:
-        rxClient.close()
+        client.close()
         embeddedServer.close()
 
         where:
@@ -355,16 +355,16 @@ class MetricsEndpointSpec extends Specification {
                 "micronaut.metrics.binders.uptime.enabled": false
         ])
         URL server = embeddedServer.getURL()
-        RxHttpClient rxClient = embeddedServer.applicationContext.createBean(RxHttpClient, server)
+        HttpClient client = embeddedServer.applicationContext.createBean(HttpClient, server)
 
         when:
-        rxClient.exchange("/metrics/$name", Map).blockingFirst()
+        client.toBlocking().exchange("/metrics/$name", Map)
 
         then:
         thrown(HttpClientResponseException)
 
         cleanup:
-        rxClient.close()
+        client.close()
         embeddedServer.close()
 
         where:
@@ -381,10 +381,10 @@ class MetricsEndpointSpec extends Specification {
                 "micronaut.metrics.binders.processor.enabled": true
         ])
         URL server = embeddedServer.getURL()
-        RxHttpClient rxClient = embeddedServer.applicationContext.createBean(RxHttpClient, server)
+        HttpClient client = embeddedServer.applicationContext.createBean(HttpClient, server)
 
         when:
-        def response = rxClient.exchange("/metrics/$name", Map).blockingFirst()
+        def response = client.toBlocking().exchange("/metrics/$name", Map)
         Map result = response.body() as Map
 
         then:
@@ -393,7 +393,7 @@ class MetricsEndpointSpec extends Specification {
         result["description"]
 
         cleanup:
-        rxClient.close()
+        client.close()
         embeddedServer.close()
 
         where:
@@ -413,10 +413,10 @@ class MetricsEndpointSpec extends Specification {
                 "micronaut.metrics.binders.processor.enabled": true
         ])
         URL server = embeddedServer.getURL()
-        RxHttpClient rxClient = embeddedServer.applicationContext.createBean(RxHttpClient, server)
+        HttpClient client = embeddedServer.applicationContext.createBean(HttpClient, server)
 
         when:
-        def response = rxClient.exchange("/metrics/$name", Map).blockingFirst()
+        def response = client.toBlocking().exchange("/metrics/$name", Map)
         Map result = response.body() as Map
 
         then:
@@ -425,7 +425,7 @@ class MetricsEndpointSpec extends Specification {
         result["description"]
 
         cleanup:
-        rxClient.close()
+        client.close()
         embeddedServer.close()
 
         where:
@@ -441,16 +441,16 @@ class MetricsEndpointSpec extends Specification {
                 "micronaut.metrics.binders.processor.enabled": false
         ])
         URL server = embeddedServer.getURL()
-        RxHttpClient rxClient = embeddedServer.applicationContext.createBean(RxHttpClient, server)
+        HttpClient client = embeddedServer.applicationContext.createBean(HttpClient, server)
 
         when:
-        rxClient.exchange("/metrics/$name", Map).blockingFirst()
+        client.toBlocking().exchange("/metrics/$name", Map)
 
         then:
         thrown(HttpClientResponseException)
 
         cleanup:
-        rxClient.close()
+        client.close()
         embeddedServer.close()
 
         where:
@@ -470,10 +470,10 @@ class MetricsEndpointSpec extends Specification {
                 "micronaut.metrics.binders.files.enabled": true
         ])
         URL server = embeddedServer.getURL()
-        RxHttpClient rxClient = embeddedServer.applicationContext.createBean(RxHttpClient, server)
+        HttpClient client = embeddedServer.applicationContext.createBean(HttpClient, server)
 
         when:
-        def response = rxClient.exchange("/metrics/$name", Map).blockingFirst()
+        def response = client.toBlocking().exchange("/metrics/$name", Map)
         Map result = response.body() as Map
 
         then:
@@ -483,7 +483,7 @@ class MetricsEndpointSpec extends Specification {
         result["baseUnit"]
 
         cleanup:
-        rxClient.close()
+        client.close()
         embeddedServer.close()
 
         where:
@@ -500,16 +500,16 @@ class MetricsEndpointSpec extends Specification {
                 "micronaut.metrics.binders.files.enabled": false
         ])
         URL server = embeddedServer.getURL()
-        RxHttpClient rxClient = embeddedServer.applicationContext.createBean(RxHttpClient, server)
+        HttpClient client = embeddedServer.applicationContext.createBean(HttpClient, server)
 
         when:
-        rxClient.exchange("/metrics/$name", Map).blockingFirst()
+        client.toBlocking().exchange("/metrics/$name", Map)
 
         then:
         thrown(HttpClientResponseException)
 
         cleanup:
-        rxClient.close()
+        client.close()
         embeddedServer.close()
 
         where:

--- a/micrometer-registry-prometheus/src/test/groovy/io/micronaut/configuration/metrics/micrometer/prometheus/management/PrometheusEndpointSpec.groovy
+++ b/micrometer-registry-prometheus/src/test/groovy/io/micronaut/configuration/metrics/micrometer/prometheus/management/PrometheusEndpointSpec.groovy
@@ -17,7 +17,7 @@ package io.micronaut.configuration.metrics.micrometer.prometheus.management
 
 import groovy.transform.NotYetImplemented
 import io.micronaut.context.ApplicationContext
-import io.micronaut.http.client.RxHttpClient
+import io.micronaut.http.client.HttpClient
 import io.micronaut.runtime.server.EmbeddedServer
 import spock.lang.AutoCleanup
 import spock.lang.Shared
@@ -29,19 +29,19 @@ class PrometheusEndpointSpec extends Specification {
             'endpoints.prometheus.sensitive':false,
             'micronaut.metrics.export.prometheus.descriptions':false
     ])
-    @Shared @AutoCleanup RxHttpClient client = embeddedServer.applicationContext
-                                                    .createBean(RxHttpClient, embeddedServer.getURL())
+    @Shared @AutoCleanup HttpClient client = embeddedServer.applicationContext
+                                                    .createBean(HttpClient, embeddedServer.getURL())
 
 
     void "test prometheus scrape"() {
         expect:
-        client.retrieve('/prometheus').blockingFirst().contains('jvm_memory_used')
+        client.toBlocking().retrieve('/prometheus').contains('jvm_memory_used')
     }
 
     @NotYetImplemented
     void "test prometheus scrape no descriptions"() {
         given:
-        def result = client.retrieve('/prometheus').blockingFirst()
+        def result = client.toBlocking().retrieve('/prometheus')
         expect:
         result.contains('jvm_memory_used')
         !result.contains('# TYPE')


### PR DESCRIPTION
- Upgrade to Micronaut 3.0.0-M4
- Use project reactor instead of micronaut-reactor (as implementation)
- Use HttpClient instead of RxHttpClient in tests

