### PR TITLE
Fix Netty's queue metrics

### DIFF
--- a/micrometer-core/src/main/java/io/micronaut/configuration/metrics/binder/netty/InstrumentedEpollEventLoopGroupFactory.java
+++ b/micrometer-core/src/main/java/io/micronaut/configuration/metrics/binder/netty/InstrumentedEpollEventLoopGroupFactory.java
@@ -22,6 +22,7 @@ import java.util.concurrent.ThreadFactory;
 
 import javax.annotation.Nullable;
 import javax.inject.Inject;
+import javax.inject.Named;
 import javax.inject.Singleton;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -30,11 +31,13 @@ import io.micronaut.context.annotation.Replaces;
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.util.StringUtils;
+import io.micronaut.http.netty.channel.EpollAvailabilityCondition;
 import io.micronaut.http.netty.channel.EpollEventLoopGroupFactory;
 import io.micronaut.http.netty.channel.EventLoopGroupConfiguration;
 import io.micronaut.http.netty.channel.EventLoopGroupFactory;
 import io.netty.channel.DefaultSelectStrategyFactory;
 import io.netty.channel.EventLoopGroup;
+import io.netty.channel.epoll.Epoll;
 import io.netty.channel.epoll.EpollEventLoopGroup;
 import io.netty.channel.epoll.EpollServerSocketChannel;
 import io.netty.channel.epoll.EpollSocketChannel;
@@ -52,8 +55,9 @@ import io.netty.util.concurrent.ThreadPerTaskExecutor;
  */
 @Singleton
 @Internal
-@Replaces(factory = EpollEventLoopGroupFactory.class)
-@Requires(beans = EpollEventLoopGroupFactory.class)
+@Replaces(bean = EpollEventLoopGroupFactory.class, named = EventLoopGroupFactory.NATIVE)
+@Named(EventLoopGroupFactory.NATIVE)
+@Requires(classes = Epoll.class, condition = EpollAvailabilityCondition.class)
 @RequiresMetrics
 @Requires(property = MICRONAUT_METRICS_BINDERS + ".netty.queues.enabled", defaultValue = StringUtils.FALSE, notEquals = StringUtils.FALSE)
 final class InstrumentedEpollEventLoopGroupFactory implements EventLoopGroupFactory {

--- a/micrometer-core/src/main/java/io/micronaut/configuration/metrics/binder/netty/InstrumentedKQueueEventLoopGroupFactory.java
+++ b/micrometer-core/src/main/java/io/micronaut/configuration/metrics/binder/netty/InstrumentedKQueueEventLoopGroupFactory.java
@@ -22,6 +22,7 @@ import java.util.concurrent.ThreadFactory;
 
 import javax.annotation.Nullable;
 import javax.inject.Inject;
+import javax.inject.Named;
 import javax.inject.Singleton;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -32,9 +33,11 @@ import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.util.StringUtils;
 import io.micronaut.http.netty.channel.EventLoopGroupConfiguration;
 import io.micronaut.http.netty.channel.EventLoopGroupFactory;
+import io.micronaut.http.netty.channel.KQueueAvailabilityCondition;
 import io.micronaut.http.netty.channel.KQueueEventLoopGroupFactory;
 import io.netty.channel.DefaultSelectStrategyFactory;
 import io.netty.channel.EventLoopGroup;
+import io.netty.channel.kqueue.KQueue;
 import io.netty.channel.kqueue.KQueueEventLoopGroup;
 import io.netty.channel.kqueue.KQueueServerSocketChannel;
 import io.netty.channel.kqueue.KQueueSocketChannel;
@@ -52,8 +55,9 @@ import io.netty.util.concurrent.ThreadPerTaskExecutor;
  */
 @Singleton
 @Internal
-@Replaces(factory = KQueueEventLoopGroupFactory.class)
-@Requires(beans = KQueueEventLoopGroupFactory.class)
+@Replaces(bean = KQueueEventLoopGroupFactory.class, named = EventLoopGroupFactory.NATIVE)
+@Named(EventLoopGroupFactory.NATIVE)
+@Requires(classes = KQueue.class, condition = KQueueAvailabilityCondition.class)
 @RequiresMetrics
 @Requires(property = MICRONAUT_METRICS_BINDERS + ".netty.queues.enabled", defaultValue = StringUtils.FALSE, notEquals = StringUtils.FALSE)
 final class InstrumentedKQueueEventLoopGroupFactory implements EventLoopGroupFactory {

--- a/micrometer-core/src/main/java/io/micronaut/configuration/metrics/binder/netty/InstrumentedNioEventLoopGroupFactory.java
+++ b/micrometer-core/src/main/java/io/micronaut/configuration/metrics/binder/netty/InstrumentedNioEventLoopGroupFactory.java
@@ -32,7 +32,6 @@ import io.micronaut.context.annotation.Requires;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.util.StringUtils;
 import io.micronaut.http.netty.channel.EventLoopGroupConfiguration;
-import io.micronaut.http.netty.channel.EventLoopGroupFactory;
 import io.micronaut.http.netty.channel.NioEventLoopGroupFactory;
 import io.netty.channel.DefaultSelectStrategyFactory;
 import io.netty.channel.EventLoopGroup;
@@ -54,11 +53,10 @@ import io.netty.util.concurrent.ThreadPerTaskExecutor;
  */
 @Singleton
 @Internal
-@Replaces(factory = NioEventLoopGroupFactory.class)
-@Requires(beans = NioEventLoopGroupFactory.class)
+@Replaces(bean = NioEventLoopGroupFactory.class)
 @RequiresMetrics
 @Requires(property = MICRONAUT_METRICS_BINDERS + ".netty.queues.enabled", defaultValue = StringUtils.FALSE, notEquals = StringUtils.FALSE)
-final class InstrumentedNioEventLoopGroupFactory implements EventLoopGroupFactory {
+final class InstrumentedNioEventLoopGroupFactory extends NioEventLoopGroupFactory {
     private final InstrumentedEventLoopTaskQueueFactory instrumentedEventLoopTaskQueueFactory;
 
     /**

--- a/micrometer-core/src/test/groovy/io/micronaut/configuration/metrics/binder/netty/MicronautNettyQueuesMetricsBinderSpec.groovy
+++ b/micrometer-core/src/test/groovy/io/micronaut/configuration/metrics/binder/netty/MicronautNettyQueuesMetricsBinderSpec.groovy
@@ -1,0 +1,160 @@
+/*
+ * Copyright 2017-2021 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.configuration.metrics.binder.netty
+
+import io.micrometer.core.instrument.Counter
+import io.micrometer.core.instrument.MeterRegistry
+import io.micrometer.core.instrument.Tags
+import io.micrometer.core.instrument.Timer
+import io.micrometer.core.instrument.search.RequiredSearch
+import io.micronaut.context.ApplicationContext
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Get
+import io.micronaut.http.client.annotation.Client
+import io.micronaut.runtime.server.EmbeddedServer
+import spock.lang.Specification
+import spock.lang.Unroll
+
+import static io.micronaut.configuration.metrics.binder.netty.NettyMetrics.COUNT
+import static io.micronaut.configuration.metrics.binder.netty.NettyMetrics.ELEMENT
+import static io.micronaut.configuration.metrics.binder.netty.NettyMetrics.EXECUTION_TIME
+import static io.micronaut.configuration.metrics.binder.netty.NettyMetrics.GLOBAL
+import static io.micronaut.configuration.metrics.binder.netty.NettyMetrics.GROUP
+import static io.micronaut.configuration.metrics.binder.netty.NettyMetrics.NETTY
+import static io.micronaut.configuration.metrics.binder.netty.NettyMetrics.PARENT
+import static io.micronaut.configuration.metrics.binder.netty.NettyMetrics.QUEUE
+import static io.micronaut.configuration.metrics.binder.netty.NettyMetrics.WAIT_TIME
+import static io.micronaut.configuration.metrics.binder.netty.NettyMetrics.WORKER
+import static io.micronaut.configuration.metrics.binder.netty.NettyMetrics.dot
+import static io.micronaut.configuration.metrics.micrometer.MeterRegistryFactory.MICRONAUT_METRICS_BINDERS
+import static io.micronaut.configuration.metrics.micrometer.MeterRegistryFactory.MICRONAUT_METRICS_ENABLED
+
+class MicronautNettyQueuesMetricsBinderSpec extends Specification {
+
+    private static def eventLoopGroupFactoryInstrumentedClasses = [
+            InstrumentedNioEventLoopGroupFactory,
+            InstrumentedEpollEventLoopGroupFactory,
+            InstrumentedKQueueEventLoopGroupFactory
+    ]
+
+    @Unroll
+    def "test getting the beans #cfg #setting"() {
+        when:
+        ApplicationContext context = ApplicationContext.run([(cfg): setting])
+
+        then:
+        eventLoopGroupFactoryInstrumentedClasses
+                .collect { context.findBean(it).isPresent() }
+                .any() == result
+
+        cleanup:
+        context.close()
+
+        where:
+        cfg                                                 | setting | result
+        MICRONAUT_METRICS_ENABLED                           | true    | false
+        MICRONAUT_METRICS_ENABLED                           | false   | false
+        MICRONAUT_METRICS_BINDERS + ".netty.queues.enabled" | true    | true
+        MICRONAUT_METRICS_BINDERS + ".netty.queues.enabled" | false   | false
+    }
+
+    def "test queue metrics are present"() {
+        when:
+        ApplicationContext context = ApplicationContext.run(
+                [MICRONAUT_METRICS_ENABLED                            : true,
+                 (MICRONAUT_METRICS_BINDERS + ".netty.queues.enabled"): true]
+        )
+        def server = context.getBean(EmbeddedServer)
+        server.start()
+
+        then:
+        eventLoopGroupFactoryInstrumentedClasses
+                .collect { context.findBean(it).isPresent() }
+                .any()
+
+        when:
+        MeterRegistry registry = context.getBean(MeterRegistry)
+        RequiredSearch search = registry.get(dot(NETTY, QUEUE, GLOBAL, WAIT_TIME))
+        search.tags(Tags.of(GROUP, PARENT))
+        Timer globalParentWaitTimer = search.timer()
+
+        search = registry.get(dot(NETTY, QUEUE, GLOBAL, EXECUTION_TIME))
+        search.tags(Tags.of(GROUP, PARENT))
+        Timer globalParentExecutionTime = search.timer()
+
+        search = registry.get(dot(NETTY, QUEUE, GLOBAL, ELEMENT, COUNT))
+        search.tags(Tags.of(GROUP, PARENT))
+        Counter globalParentTaskCounter = search.counter()
+
+        search = registry.get(dot(NETTY, QUEUE, GLOBAL, WAIT_TIME))
+        search.tags(Tags.of(GROUP, WORKER))
+        Timer globalWorkerWaitTimer = search.timer()
+
+        search = registry.get(dot(NETTY, QUEUE, GLOBAL, EXECUTION_TIME))
+        search.tags(Tags.of(GROUP, WORKER))
+        Timer globalWorkerExecutionTimer = search.timer()
+
+        search = registry.get(dot(NETTY, QUEUE, GLOBAL, ELEMENT, COUNT))
+        search.tags(Tags.of(GROUP, WORKER))
+        Counter globalWorkerTaskCounter = search.counter()
+
+        then:
+        globalParentWaitTimer
+        globalParentExecutionTime
+        globalParentTaskCounter
+
+        globalWorkerWaitTimer
+        globalWorkerWaitTimer.count() == 0
+        globalWorkerExecutionTimer
+        globalWorkerExecutionTimer.count() == 0
+        globalWorkerTaskCounter
+        globalWorkerTaskCounter.count() == 0
+
+        when:
+        DummyClient client = context.getBean(DummyClient)
+
+        then:
+        client.test() == 'root'
+        client.test() == 'root'
+        client.test() == 'root'
+        client.test() == 'root'
+        client.test() == 'root'
+        client.test() == 'root'
+        globalParentWaitTimer.count() > 0
+        globalParentExecutionTime.count() > 0
+        globalWorkerWaitTimer.count() > 0
+        globalWorkerExecutionTimer.count() > 0
+        globalParentTaskCounter.count() > 0
+        globalWorkerTaskCounter.count() > 0
+
+        cleanup:
+        context.close()
+    }
+
+    @Client('/nettyQueuesMetricsTest')
+    private static interface DummyClient {
+        @Get
+        String test()
+    }
+
+    @Controller('/nettyQueuesMetricsTest')
+    private static class DummyController {
+        @Get
+        String root() {
+            return "root"
+        }
+    }
+}


### PR DESCRIPTION
Due to bean type and names inconsistency between the `DefaultEventLoopGroupFactory` in the micronaut-core
and `Instrumented{Epoll,KQueue,Nio}EventLoopGroupFactory` in the micrometer-core, instrumented beans
were not injected. As a result, metrics were not working.

This PR fixes annotations on the instrumented beans and adds appropriate tests.

I've run test locally against the nio implementation and the kqueue one on MacOS.