### PR TITLE
Remove 'descriptions' from Elastic settings

### DIFF
--- a/src/main/docs/guide/metricsAndReporters/metricsAndReportersElastic.adoc
+++ b/src/main/docs/guide/metricsAndReporters/metricsAndReportersElastic.adoc
@@ -10,7 +10,6 @@ for more options.
 |*Name* |*Description*
 |enabled |Whether to enable the reporter. Could disable to local dev for example. Default: `true`
 |step |How frequently to report metrics. Default: `PT1M` (1 min).  See `java.time.Duration#parse(CharSequence)`
-|descriptions | Boolean if meter descriptions should be sent to InfluxDB. Turn this off to minimize the amount of data sent on each scrape. Default: `true`
 |=======
 
 .Example Elastic Config


### PR DESCRIPTION
The Elastic meter registry does not have this setting.