### PR TITLE
Fix GraalVM warnings

### DIFF
--- a/micrometer-core/src/main/resources/META-INF/native-image/io.micronaut.micrometer/micronaut-micrometer-core/native-image.properties
+++ b/micrometer-core/src/main/resources/META-INF/native-image/io.micronaut.micrometer/micronaut-micrometer-core/native-image.properties
@@ -14,4 +14,5 @@
 # limitations under the License.
 #
 
-Args = --initialize-at-build-time=io.micrometer.core
+Args = --initialize-at-build-time=io.micrometer.core \
+       --initialize-at-run-time=io.micronaut.configuration.metrics.binder.cache.$MicronautCaffeineCacheMetricsBinder$Definition,io.micronaut.configuration.metrics.binder.cache.$JCacheMetricsBinder$Definition,io.micronaut.configuration.metrics.binder.datasource.$DataSourcePoolMetricsBinderFactory$DataSourceMeterBinder0$Definition


### PR DESCRIPTION
This PR fixes the following GraalVM warnings:

```
Warning: class initialization of class io.micronaut.configuration.metrics.binder.cache.$MicronautCaffeineCacheMetricsBinder$Definition failed with exception java.lang.NoClassDefFoundError: io/micronaut/cache/Cache. This class will be initialized at run time because option --allow-incomplete-classpath is used for image building. Use the option --initialize-at-run-time=io.micronaut.configuration.metrics.binder.cache.$MicronautCaffeineCacheMetricsBinder$Definition to explicitly request delayed initialization of this class.
Warning: class initialization of class io.micronaut.configuration.metrics.binder.cache.$JCacheMetricsBinder$Definition failed with exception java.lang.NoClassDefFoundError: javax/cache/CacheManager. This class will be initialized at run time because option --allow-incomplete-classpath is used for image building. Use the option --initialize-at-run-time=io.micronaut.configuration.metrics.binder.cache.$JCacheMetricsBinder$Definition to explicitly request delayed initialization of this class.
Warning: class initialization of class io.micronaut.configuration.metrics.binder.datasource.$DataSourcePoolMetricsBinderFactory$DataSourceMeterBinder0$Definition failed with exception java.lang.NoClassDefFoundError: io/micronaut/jdbc/metadata/DataSourcePoolMetadata. This class will be initialized at run time because option --allow-incomplete-classpath is used for image building. Use the option --initialize-at-run-time=io.micronaut.configuration.metrics.binder.datasource.$DataSourcePoolMetricsBinderFactory$DataSourceMeterBinder0$Definition to explicitly request delayed initialization of this class.
```