### PR TITLE
Fix 337 Mono and Flux are now generated from Publishers

### DIFF
--- a/micrometer-core/build.gradle
+++ b/micrometer-core/build.gradle
@@ -30,6 +30,7 @@ dependencies {
     testImplementation "io.micronaut:micronaut-http-client"
 
     testImplementation "io.micronaut.sql:micronaut-jdbc"
+    testImplementation "io.micronaut.rxjava2:micronaut-rxjava2"
     testImplementation "org.codehaus.groovy:groovy-json:$groovyVersion"
     testImplementation "io.netty:netty-buffer"
     testImplementation "io.netty:netty-transport"

--- a/micrometer-core/src/main/java/io/micronaut/configuration/metrics/micrometer/intercept/CountedInterceptor.java
+++ b/micrometer-core/src/main/java/io/micronaut/configuration/metrics/micrometer/intercept/CountedInterceptor.java
@@ -27,6 +27,7 @@ import io.micronaut.core.annotation.AnnotationMetadata;
 import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.async.publisher.Publishers;
 import io.micronaut.core.util.StringUtils;
+import org.reactivestreams.Publisher;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
@@ -68,12 +69,12 @@ public class CountedInterceptor implements MethodInterceptor<Object, Object> {
                         }
                         Object reactiveResult;
                         if (context.getReturnType().isSingleResult()) {
-                            Mono<?> single = Publishers.convertPublisher(interceptResult, Mono.class);
+                            Mono<?> single = Mono.from(Publishers.convertPublisher(interceptResult, Publisher.class));
                             reactiveResult = single
                                     .doOnError(throwable -> doCount(metadata, metricName, throwable))
                                     .doOnSuccess(o -> doCount(metadata, metricName, null));
                         } else {
-                            Flux<?> flowable = Publishers.convertPublisher(interceptResult, Flux.class);
+                            Flux<?> flowable = Flux.from(Publishers.convertPublisher(interceptResult, Publisher.class));
                             reactiveResult = flowable
                                     .doOnError(throwable -> doCount(metadata, metricName, throwable))
                                     .doOnComplete(() -> doCount(metadata, metricName, null));

--- a/micrometer-core/src/test/groovy/io/micronaut/configuration/metrics/management/endpoint/FilteredMetricsEndpointSpec.groovy
+++ b/micrometer-core/src/test/groovy/io/micronaut/configuration/metrics/management/endpoint/FilteredMetricsEndpointSpec.groovy
@@ -16,6 +16,8 @@
 package io.micronaut.configuration.metrics.management.endpoint
 
 import groovy.util.logging.Slf4j
+import io.micrometer.core.annotation.Counted
+import io.micrometer.core.annotation.Timed
 import io.micrometer.core.instrument.MeterRegistry
 import io.micrometer.core.instrument.composite.CompositeMeterRegistry
 import io.micrometer.core.instrument.config.MeterFilter
@@ -33,6 +35,7 @@ import io.micronaut.http.annotation.Controller
 import io.micronaut.http.annotation.Get
 import io.micronaut.http.client.HttpClient
 import io.micronaut.runtime.server.EmbeddedServer
+import io.reactivex.Single
 import jakarta.inject.Singleton
 import reactor.core.publisher.Mono
 import spock.lang.AutoCleanup
@@ -70,6 +73,7 @@ class FilteredMetricsEndpointSpec extends Specification {
 
         expect:
         client.toBlocking().exchange(HttpRequest.GET('/filtered/hello/fred'), String).body() == "Hello Fred"
+        client.toBlocking().exchange(HttpRequest.GET('/filtered/rxjava2/fred'), String).body() == "Hello Fred"
     }
 
     void "test the filter beans are available"() {
@@ -135,6 +139,13 @@ class FilteredMetricsEndpointSpec extends Specification {
         @Get("/filtered/hello/{name}")
         Mono<String> hello(@NotBlank String name) {
             return Mono.just("Hello ${name.capitalize()}".toString())
+        }
+
+        @Timed
+        @Counted
+        @Get("/filtered/rxjava2/{name}")
+        Single<String> rxjava(@NotBlank String name) {
+            return Single.just("Hello ${name.capitalize()}".toString())
         }
     }
 


### PR DESCRIPTION
Fix #337 

Now Mono and Flux are created from `Publisher` interface inside `CountedInterceptor` and `TimedInterceptor`. Also added test that covers scenario when `@Timed` annotation  and `@Counted` annotation are present.