### PR TITLE
Configuring R2DBC metrics binder

### DIFF
--- a/micrometer-core/build.gradle
+++ b/micrometer-core/build.gradle
@@ -13,6 +13,7 @@ dependencies {
     compileOnly "io.micronaut:micronaut-management"
     compileOnly "io.grpc:grpc-api"
     compileOnly "io.micronaut.sql:micronaut-jdbc"
+    compileOnly "io.r2dbc:r2dbc-pool"
     compileOnly 'io.micronaut.cache:micronaut-cache-core'
     compileOnly "io.netty:netty-buffer"
     compileOnly "io.netty:netty-transport"
@@ -29,6 +30,7 @@ dependencies {
     testRuntimeOnly "io.micronaut:micronaut-http-server-netty"
     testImplementation "io.micronaut:micronaut-http-client"
     testImplementation "io.micronaut.sql:micronaut-jdbc"
+    testImplementation "io.r2dbc:r2dbc-pool"
     testImplementation "io.micronaut.rxjava2:micronaut-rxjava2"
     testImplementation "org.codehaus.groovy:groovy-json:$groovyVersion"
     testImplementation "io.netty:netty-buffer"

--- a/micrometer-core/src/main/java/io/micronaut/configuration/metrics/binder/r2dbc/R2dbcPoolMetricsBinder.java
+++ b/micrometer-core/src/main/java/io/micronaut/configuration/metrics/binder/r2dbc/R2dbcPoolMetricsBinder.java
@@ -21,7 +21,6 @@ import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.binder.MeterBinder;
 import javax.validation.constraints.NotNull;
 
-import io.r2dbc.pool.ConnectionPool;
 import io.r2dbc.pool.PoolMetrics;
 
 import java.util.function.Function;
@@ -45,7 +44,7 @@ public class R2dbcPoolMetricsBinder implements MeterBinder {
 
     @Override
     public void bindTo(@NotNull MeterRegistry registry) {
-        if(poolMetrics != null) {
+        if (poolMetrics != null) {
             bindToPoolMetrics(registry, "acquired", PoolMetrics::acquiredSize);
             bindToPoolMetrics(registry, "allocated", PoolMetrics::allocatedSize);
             bindToPoolMetrics(registry, "idle", PoolMetrics::idleSize);

--- a/micrometer-core/src/main/java/io/micronaut/configuration/metrics/binder/r2dbc/R2dbcPoolMetricsBinder.java
+++ b/micrometer-core/src/main/java/io/micronaut/configuration/metrics/binder/r2dbc/R2dbcPoolMetricsBinder.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2017-2019 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.configuration.metrics.binder.r2dbc;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.Tags;
+import io.micrometer.core.instrument.binder.MeterBinder;
+import javax.validation.constraints.NotNull;
+
+import io.r2dbc.pool.ConnectionPool;
+import io.r2dbc.pool.PoolMetrics;
+
+import java.util.function.Function;
+
+/**
+ * A {@link MeterBinder} for a {@link ConnectionPool}.
+ *
+ * @author Leonardo Schick
+ * @author Caroline Medeiros
+ * @since 4.2.1
+ */
+public class R2dbcPoolMetricsBinder implements MeterBinder {
+
+    private final PoolMetrics poolMetrics;
+    private final Iterable<Tag> tags;
+
+    public R2dbcPoolMetricsBinder(PoolMetrics metrics, String dataSourceName, Iterable<Tag> tags) {
+        this.poolMetrics = metrics;
+        this.tags = Tags.concat(tags, "name", dataSourceName);
+    }
+
+    @Override
+    public void bindTo(@NotNull MeterRegistry registry) {
+        if(poolMetrics != null) {
+            bindToPoolMetrics(registry, "acquired", PoolMetrics::acquiredSize);
+            bindToPoolMetrics(registry, "allocated", PoolMetrics::allocatedSize);
+            bindToPoolMetrics(registry, "idle", PoolMetrics::idleSize);
+            bindToPoolMetrics(registry, "pending", PoolMetrics::pendingAcquireSize);
+            bindToPoolMetrics(registry, "max.allocated", PoolMetrics::getMaxAllocatedSize);
+            bindToPoolMetrics(registry, "max.pending", PoolMetrics::getMaxPendingAcquireSize);
+        }
+    }
+
+    private void bindToPoolMetrics(
+        MeterRegistry registry,
+        String metricName,
+        Function<PoolMetrics, Integer> function
+    ) {
+        registry.gauge(
+            "r2dbc.pool" + "." + metricName,
+            tags,
+            poolMetrics,
+            (m) -> function.apply(m).doubleValue()
+        );
+    }
+}

--- a/micrometer-core/src/main/java/io/micronaut/configuration/metrics/binder/r2dbc/R2dbcPoolMetricsBinderFactory.java
+++ b/micrometer-core/src/main/java/io/micronaut/configuration/metrics/binder/r2dbc/R2dbcPoolMetricsBinderFactory.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2017-2019 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.configuration.metrics.binder.r2dbc;
+
+import io.micrometer.core.instrument.binder.MeterBinder;
+import io.micronaut.configuration.metrics.annotation.RequiresMetrics;
+import io.micronaut.context.annotation.EachBean;
+import io.micronaut.context.annotation.Factory;
+import io.micronaut.context.annotation.Parameter;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.core.util.StringUtils;
+import io.r2dbc.pool.ConnectionPool;
+import io.r2dbc.pool.PoolMetrics;
+import io.r2dbc.spi.ConnectionFactory;
+
+import java.util.Collections;
+
+import static io.micronaut.configuration.metrics.micrometer.MeterRegistryFactory.MICRONAUT_METRICS_BINDERS;
+
+/**
+ * Instruments Micronaut related r2dbc pool metrics via Micrometer.
+ *
+ * @author Leonardo Schick
+ * @author Caroline Medeiros
+ * @since 4.2.1
+ */
+@Factory
+@RequiresMetrics
+@Requires(property = MICRONAUT_METRICS_BINDERS + ".r2dbc.enabled", notEquals = StringUtils.FALSE)
+public class R2dbcPoolMetricsBinderFactory {
+
+    /**
+     * Method to wire beans for each type of datasource.
+     *
+     * @param dataSourceName    The parameterized name of the datasource
+     * @param factory           The datasource factory object to use for the binder
+     * @return                  MeterBinders for each configured {@link ConnectionFactory}
+     */
+    @EachBean(ConnectionFactory.class)
+    @Requires(beans = {ConnectionFactory.class})
+    public MeterBinder r2dbcPoolMeterBinder(
+            @Parameter String dataSourceName,
+            ConnectionFactory factory) {
+        PoolMetrics poolMetrics = null;
+        if(factory instanceof ConnectionPool) {
+            poolMetrics = ((ConnectionPool) factory).getMetrics().orElse(null);
+        }
+
+        return new R2dbcPoolMetricsBinder(poolMetrics, dataSourceName, Collections.emptyList());
+    }
+}

--- a/micrometer-core/src/main/java/io/micronaut/configuration/metrics/binder/r2dbc/R2dbcPoolMetricsBinderFactory.java
+++ b/micrometer-core/src/main/java/io/micronaut/configuration/metrics/binder/r2dbc/R2dbcPoolMetricsBinderFactory.java
@@ -55,7 +55,7 @@ public class R2dbcPoolMetricsBinderFactory {
             @Parameter String dataSourceName,
             ConnectionFactory factory) {
         PoolMetrics poolMetrics = null;
-        if(factory instanceof ConnectionPool) {
+        if (factory instanceof ConnectionPool) {
             poolMetrics = ((ConnectionPool) factory).getMetrics().orElse(null);
         }
 

--- a/micrometer-core/src/main/java/io/micronaut/configuration/metrics/binder/r2dbc/package-info.java
+++ b/micrometer-core/src/main/java/io/micronaut/configuration/metrics/binder/r2dbc/package-info.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2017-2019 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Contains classes that bind metrics for configured R2DBC data sources.
+ *
+ * @author Leonardo Schick
+ * @author Caroline Medeiros
+ * @since 4.2.1
+ */
+package io.micronaut.configuration.metrics.binder.r2dbc;

--- a/micrometer-core/src/test/groovy/io/micronaut/configuration/metrics/binder/r2dbc/R2dbcPoolMetricsBinderFactorySpec.groovy
+++ b/micrometer-core/src/test/groovy/io/micronaut/configuration/metrics/binder/r2dbc/R2dbcPoolMetricsBinderFactorySpec.groovy
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2017-2019 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.configuration.metrics.binder.r2dbc
+
+import io.r2dbc.pool.ConnectionPool
+import io.r2dbc.pool.PoolMetrics
+import io.r2dbc.spi.Connection
+import io.r2dbc.spi.ConnectionFactory
+import io.r2dbc.spi.ConnectionFactoryMetadata
+import org.reactivestreams.Publisher
+import spock.lang.Specification
+
+class R2dbcPoolMetricsBinderFactorySpec extends Specification {
+
+    def "test getting metrics from r2dbc pool"() {
+        given:
+        def r2dbcPoolMetricsBinderFactory = new R2dbcPoolMetricsBinderFactory()
+        def pool = Mock(ConnectionPool)
+        def metrics = new StubMetrics()
+        pool.getMetrics() >> Optional.of(metrics)
+
+        when:
+        def meterBinder = r2dbcPoolMetricsBinderFactory.r2dbcPoolMeterBinder("foo", pool)
+
+        then:
+        meterBinder.@poolMetrics == metrics
+    }
+
+    def "test getting empty metrics from r2dbc pool"() {
+        given:
+        def r2dbcPoolMetricsBinderFactory = new R2dbcPoolMetricsBinderFactory()
+        def pool = Mock(ConnectionPool)
+        pool.getMetrics() >> Optional.empty()
+
+        when:
+        def meterBinder = r2dbcPoolMetricsBinderFactory.r2dbcPoolMeterBinder("foo", pool)
+
+        then:
+        meterBinder.@poolMetrics == null
+    }
+
+    def "test ignoring metrics when factory is not r2dbc pool"() {
+        given:
+        def r2dbcPoolMetricsBinderFactory = new R2dbcPoolMetricsBinderFactory()
+        def factory = Mock(StubFactory)
+
+        when:
+        def meterBinder = r2dbcPoolMetricsBinderFactory.r2dbcPoolMeterBinder("foo", factory)
+
+        then:
+        meterBinder.@poolMetrics == null
+    }
+
+    class StubFactory implements ConnectionFactory {
+
+        @Override
+        Publisher<? extends Connection> create() {
+            return null
+        }
+
+        @Override
+        ConnectionFactoryMetadata getMetadata() {
+            return null
+        }
+    }
+
+    class StubMetrics implements PoolMetrics {
+
+        @Override
+        int acquiredSize() {
+            return 0
+        }
+
+        @Override
+        int allocatedSize() {
+            return 0
+        }
+
+        @Override
+        int idleSize() {
+            return 0
+        }
+
+        @Override
+        int pendingAcquireSize() {
+            return 0
+        }
+
+        @Override
+        int getMaxAllocatedSize() {
+            return 0
+        }
+
+        @Override
+        int getMaxPendingAcquireSize() {
+            return 0
+        }
+    }
+}

--- a/micrometer-core/src/test/groovy/io/micronaut/configuration/metrics/binder/r2dbc/R2dbcPoolMetricsBinderSpec.groovy
+++ b/micrometer-core/src/test/groovy/io/micronaut/configuration/metrics/binder/r2dbc/R2dbcPoolMetricsBinderSpec.groovy
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2017-2019 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.configuration.metrics.binder.r2dbc
+
+import io.micrometer.core.instrument.MeterRegistry
+import io.micrometer.core.instrument.Tags
+import io.r2dbc.pool.PoolMetrics
+import spock.lang.Specification
+
+class R2dbcPoolMetricsBinderSpec extends Specification {
+
+    MeterRegistry meterRegistry = Mock(MeterRegistry)
+
+    def "test registry metrics"() {
+        given:
+        PoolMetrics poolMetrics = Mock(PoolMetrics)
+        R2dbcPoolMetricsBinder r2dbcPoolMetricsBinder = new R2dbcPoolMetricsBinder(
+                poolMetrics,
+                "foo",
+                []
+        )
+
+        when:
+        r2dbcPoolMetricsBinder.bindTo(meterRegistry)
+
+        then:
+        1 * meterRegistry.gauge('r2dbc.pool.acquired', Tags.of("name","foo"), poolMetrics, _)
+        1 * meterRegistry.gauge('r2dbc.pool.allocated', Tags.of("name","foo"), poolMetrics, _)
+        1 * meterRegistry.gauge('r2dbc.pool.idle', Tags.of("name","foo"), poolMetrics, _)
+        1 * meterRegistry.gauge('r2dbc.pool.pending', Tags.of("name","foo"), poolMetrics, _)
+        1 * meterRegistry.gauge('r2dbc.pool.max.allocated', Tags.of("name","foo"), poolMetrics, _)
+        1 * meterRegistry.gauge('r2dbc.pool.max.pending', Tags.of("name","foo"), poolMetrics, _)
+        0 * _._
+    }
+
+    def "test do not registry metrics"() {
+        given:
+        R2dbcPoolMetricsBinder r2dbcPoolMetricsBinder = new R2dbcPoolMetricsBinder(
+                null,
+                "foo",
+                []
+        )
+
+        when:
+        r2dbcPoolMetricsBinder.bindTo(meterRegistry)
+
+        then:
+        0 * _._
+    }
+}


### PR DESCRIPTION
I am adding a meter binder for R2DBC pool metrics. Metrics are extracted from class reactor.pool.Pool.PoolMetrics.
I could only bind metrics from class org.reactivestreams.Publisher.ConnectionFactory and casting to io.r2dbc.pool.ConnectionPool when possible, because the way Micrometer register the ConnectionPool.

It is my first time contributing so I did not know how to document the version in JavaDocs. I used the next version 4.2.1.