### PR TITLE
issue-405: quick fix for accidentally removed instrumentations

### DIFF
--- a/micrometer-core/src/main/java/io/micronaut/configuration/metrics/binder/executor/ExecutorServiceMetricsBinder.java
+++ b/micrometer-core/src/main/java/io/micronaut/configuration/metrics/binder/executor/ExecutorServiceMetricsBinder.java
@@ -69,7 +69,7 @@ public class ExecutorServiceMetricsBinder implements BeanCreatedEventListener<Ex
         }
         // Netty EventLoopGroups require separate instrumentation.
         if (unwrapped.getClass().getName().startsWith("io.netty")) {
-            return unwrapped;
+            return executorService;
         }
 
         MeterRegistry meterRegistry = meterRegistryProvider.get();


### PR DESCRIPTION
Quick fix for accidentally removed instrumentations in ExecutorServiceMetricsBinder:
- just return the original executorService instead of the unwrapped io.netty class

The proper fix would be to rethink the original fix for #62 and find a less brittle solution, but in the meantime this obvious error should be fixed IMO.

It would also be nice if it were backported to previous stable branches