### PR TITLE
Manage micrometer-core in the catalog

### DIFF
--- a/buildSrc/src/main/groovy/io.micronaut.build.internal.micrometer-module.gradle
+++ b/buildSrc/src/main/groovy/io.micronaut.build.internal.micrometer-module.gradle
@@ -7,7 +7,7 @@ plugins {
 }
 
 dependencies {
-    api libs.micrometer.core
+    api libs.managed.micrometer.core
     implementation 'jakarta.inject:jakarta.inject-api:2.0.1'
 }
 

--- a/buildSrc/src/main/groovy/io.micronaut.build.internal.micrometer-registry.gradle
+++ b/buildSrc/src/main/groovy/io.micronaut.build.internal.micrometer-registry.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 dependencies {
-    api libs.micrometer.core
+    api libs.managed.micrometer.core
     api libs.validation.api
     api projects.micrometerCore
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,9 +15,11 @@ cache-api = { module = 'javax.cache:cache-api', version.ref = 'jcache' }
 groovy-json = { module = 'org.codehaus.groovy:groovy-json', version.ref = 'groovy' }
 grpc-api = { module = 'io.grpc:grpc-api' }
 logback-classic = { module = 'ch.qos.logback:logback-classic', version.ref = 'logback-classic' }
+
 managed-metrics-core = { module = 'io.dropwizard.metrics:metrics-core', version.ref = 'managed-metrics-core' }
 managed-micrometer-registry-new-relic-telemetry = { module = 'com.newrelic.telemetry:micrometer-registry-new-relic', version.ref = 'managed-new-relic-registry' }
-micrometer-core = { module = 'io.micrometer:micrometer-core', version.ref = 'managed-micrometer' }
+managed-micrometer-core = { module = 'io.micrometer:micrometer-core', version.ref = 'managed-micrometer' }
+
 micrometer-registry-appoptics = { module = 'io.micrometer:micrometer-registry-appoptics', version.ref = 'managed-micrometer' }
 micrometer-registry-atlas = { module = 'io.micrometer:micrometer-registry-atlas', version.ref = 'managed-micrometer' }
 micrometer-registry-azure-monitor = { module = 'io.micrometer:micrometer-registry-azure-monitor', version.ref = 'managed-micrometer' }


### PR DESCRIPTION
This allows us to remove managed-micrometer-core from the core catalog

https://github.com/micronaut-projects/micronaut-core/blob/8c457bf87bbbf025b02da52e94dd3b803400d85c/gradle/libs.versions.toml#L260

Which means we could close this:

https://github.com/micronaut-projects/micronaut-core/issues/7491

Would require a new minor release of this, with the branch changed to 3.6.x