### PR TITLE
Remove sentence about obsolete netty binding control property from docs

### DIFF
--- a/src/main/docs/guide/metricsConcepts.adoc
+++ b/src/main/docs/guide/metricsConcepts.adoc
@@ -200,8 +200,6 @@ If you use `io.micronaut.sql:micronaut-jdbc-tomcat` or `io.micronaut.sql:microna
 
 ===== Netty Server Metrics
 
-The main *Control Property* for Netty server metrics is `micronaut.metrics.binders.netty.enabled`, which is *false* by default.
-
 Currently, the following binders are provided to instrument Netty server:
 
 * *EventLoopGroupFactoryBinder*: Instrument and expose event loop group queues metrics; use `micronaut.metrics.binders.netty.queues.enabled` to toggle. Default is *false*. The queues' size and tasks wait and execution time are exposed.


### PR DESCRIPTION
Can't find any reference to this property in the code.
Fixes #437