### PR TITLE
build: define group id in gradle.properties

### DIFF
--- a/buildSrc/src/main/groovy/io.micronaut.build.internal.micrometer-base.gradle
+++ b/buildSrc/src/main/groovy/io.micronaut.build.internal.micrometer-base.gradle
@@ -1,2 +1,0 @@
-version projectVersion
-group 'io.micronaut.micrometer'

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,5 @@
 projectVersion=4.7.0
+projectGroup=io.micronaut.micrometer
 micronautDocsVersion=2.0.0
 micronautVersion=3.7.3
 micronautTestVersion=3.7.0


### PR DESCRIPTION
[4.7.0 release failed because group id was not defined in `gradle.properties`](https://github.com/micronaut-projects/micronaut-micrometer/actions/runs/3763594703/jobs/6397243305)