### PR TITLE
chore: add projectGroupId to gradle.properties

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,5 @@
 projectVersion=5.0.0-SNAPSHOT
+projectGroupId=io.micronaut.micrometer
 micronautDocsVersion=2.0.0
 micronautVersion=4.0.0-SNAPSHOT
 micronautTestVersion=4.0.0-SNAPSHOT


### PR DESCRIPTION
This PR adds the missing `projectGroupId` to `gradle.properties`, which is necessary to [locate generated artifacts](https://github.com/micronaut-projects/micronaut-micrometer/actions/runs/3763594703/workflow#L54) for provenance generation. 

Signed-off-by: behnazh-w <behnaz.hassanshahi@oracle.com>