### PR TITLE
Adds missing GraalVM config

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-projectVersion=4.7.0
+projectVersion=4.7.1-SNAPSHOT
 micronautDocsVersion=2.0.0
 micronautVersion=3.7.3
 micronautTestVersion=3.7.0

--- a/micrometer-core/src/main/resources/META-INF/native-image/io.micronaut.micrometer/micronaut-micrometer-core/native-image.properties
+++ b/micrometer-core/src/main/resources/META-INF/native-image/io.micronaut.micrometer/micronaut-micrometer-core/native-image.properties
@@ -14,5 +14,5 @@
 # limitations under the License.
 #
 
-Args = --initialize-at-build-time=io.micrometer.core \
+Args = --initialize-at-build-time=io.micrometer.core,io.micrometer.common.util.internal.logging.LocationAwareSlf4JLogger \
        --initialize-at-run-time=io.micronaut.configuration.metrics.binder.cache.$MicronautCaffeineCacheMetricsBinder$Definition,io.micronaut.configuration.metrics.binder.cache.$JCacheMetricsBinder$Definition,io.micronaut.configuration.metrics.binder.datasource.$DataSourcePoolMetricsBinderFactory$DataSourceMeterBinder0$Definition


### PR DESCRIPTION
- Adds missing `io.micrometer.core,io.micrometer.common.util.internal.logging.LocationAwareSlf4JLogger` to `initialize-at-build-time`.

Fixes #486