### PR TITLE
Do not initialize io.micrometer.core classes with logger at build time

### DIFF
--- a/micrometer-core/src/main/resources/META-INF/native-image/io.micronaut.micrometer/micronaut-micrometer-core/native-image.properties
+++ b/micrometer-core/src/main/resources/META-INF/native-image/io.micronaut.micrometer/micronaut-micrometer-core/native-image.properties
@@ -15,4 +15,5 @@
 #
 
 Args = --initialize-at-build-time=io.micrometer.core,io.micrometer.common.util.internal.logging.LocationAwareSlf4JLogger \
-       --initialize-at-run-time=io.micronaut.configuration.metrics.binder.cache.$MicronautCaffeineCacheMetricsBinder$Definition,io.micronaut.configuration.metrics.binder.cache.$JCacheMetricsBinder$Definition,io.micronaut.configuration.metrics.binder.datasource.$DataSourcePoolMetricsBinderFactory$DataSourceMeterBinder0$Definition
+       --initialize-at-run-time=io.micronaut.configuration.metrics.binder.cache.$MicronautCaffeineCacheMetricsBinder$Definition,io.micronaut.configuration.metrics.binder.cache.$JCacheMetricsBinder$Definition,io.micronaut.configuration.metrics.binder.datasource.$DataSourcePoolMetricsBinderFactory$DataSourceMeterBinder0$Definition \
+       --initialize-at-run-time=io.micrometer.core.instrument.push.PushMeterRegistry,io.micrometer.core.instrument.binder.jvm.JvmGcMetrics,io.micrometer.core.instrument.internal.DefaultGauge,io.micrometer.core.instrument.binder.jvm.ExecutorServiceMetrics


### PR DESCRIPTION
### Issue

* Create the following micronaut application (jdk 17, micrometer-cloudwatch feature): https://micronaut.io/launch?type=DEFAULT&name=demo&package=com.example&javaVersion=JDK_17&lang=JAVA&build=GRADLE&test=JUNIT&features=micrometer-cloudwatch&version=3.8.3
* Run `./gradlew nativeBuild`.
* Results in the following exception:
  ```
  Error: Classes that should be initialized at run time got initialized during image building:
  io.micrometer.common.util.internal.logging.Slf4JLoggerFactory was unintentionally initialized at build time. To see why io.micrometer.common.util.internal.logging.Slf4JLoggerFactory got initialized use --trace-class-initialization=io.micrometer.common.util.internal.logging.Slf4JLoggerFactory
  To see how the classes got initialized, use --trace-class-initialization=io.micrometer.common.util.internal.logging.Slf4JLoggerFactory
  Error: Use -H:+ReportExceptionStackTraces to print stacktrace of underlying exception
   ```

### Fix

Adding this part to `build.gradle` fixes the build (initializing problematic classes that use slf4j logging during run time):
```
graalvmNative {
    binaries.configureEach {
        buildArgs.addAll(
                "--initialize-at-run-time=io.micrometer.core.instrument.push.PushMeterRegistry,io.micrometer.core.instrument.binder.jvm.JvmGcMetrics,io.micrometer.core.instrument.internal.DefaultGauge,io.micrometer.core.instrument.binder.jvm.ExecutorServiceMetrics"
        )
    }
}
```
Therefore I added it to the `native-image.properties` file.

### Remarks

Building a micronaut micrometer application doesn't produce the error, only when building micrometer-cloudwatch. I am not entirely sure what the reason is, but it seems better to add the fix to the `micrometer-core/.../native-image.properties` file to avoid similar issues.