### PR TITLE
Add oracle cloud module to docs

### DIFF
--- a/src/main/docs/guide/metricsAndReporters/metricsAndReportersOracleCloud.adoc
+++ b/src/main/docs/guide/metricsAndReporters/metricsAndReportersOracleCloud.adoc
@@ -1,0 +1,3 @@
+The https://docs.oracle.com/en-us/iaas/Content/Monitoring/Concepts/monitoringoverview.htm[OCI Monitoring service] enables you to actively and passively monitor your cloud resources using the Metrics and Alarms features on Oracle Cloud.
+
+To configuration the module see the documentation for https://micronaut-projects.github.io/micronaut-oracle-cloud/latest/guide/#micrometer[Micrometer Support For Oracle Monitoring] in the Oracle Cloud module.

--- a/src/main/docs/guide/metricsAndReporters/metricsAndReportersOracleCloud.adoc
+++ b/src/main/docs/guide/metricsAndReporters/metricsAndReportersOracleCloud.adoc
@@ -1,3 +1,3 @@
 The https://docs.oracle.com/en-us/iaas/Content/Monitoring/Concepts/monitoringoverview.htm[OCI Monitoring service] enables you to actively and passively monitor your cloud resources using the Metrics and Alarms features on Oracle Cloud.
 
-To configuration the module see the documentation for https://micronaut-projects.github.io/micronaut-oracle-cloud/latest/guide/#micrometer[Micrometer Support For Oracle Monitoring] in the Oracle Cloud module.
+To configure the module see the documentation for https://micronaut-projects.github.io/micronaut-oracle-cloud/latest/guide/#micrometer[Micrometer Support For Oracle Monitoring] in the Oracle Cloud module.

--- a/src/main/docs/guide/toc.yml
+++ b/src/main/docs/guide/toc.yml
@@ -20,6 +20,7 @@ metricsAndReporters:
   metricsAndReportersKairos: Kairos Registry
   metricsAndReportersNewRelic: New Relic Registry
   metricsAndReportersNewRelicTelemetry: New Relic Telemetry Registry
+  metricsAndReportersOracleCloud: Oracle Cloud Monitoring Registry
   metricsAndReportersPrometheus: Prometheus Registry
   metricsAndReportersSignalFx: SignalFx Registry
   metricsAndReportersStackdriver: Stackdriver Registry


### PR DESCRIPTION
Adds the Oracle Cloud Monitoring module to the list of modules in the documentation.