### PR TITLE
Never use user input for web metrics

### DIFF
--- a/micrometer-core/src/main/java/io/micronaut/configuration/metrics/binder/web/ClientRequestMetricRegistryFilter.java
+++ b/micrometer-core/src/main/java/io/micronaut/configuration/metrics/binder/web/ClientRequestMetricRegistryFilter.java
@@ -18,6 +18,8 @@ package io.micronaut.configuration.metrics.binder.web;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micronaut.configuration.metrics.annotation.RequiresMetrics;
 import io.micronaut.context.annotation.Requires;
+import io.micronaut.core.util.StringUtils;
+import io.micronaut.http.HttpAttributes;
 import io.micronaut.http.HttpResponse;
 import io.micronaut.http.MutableHttpRequest;
 import io.micronaut.http.annotation.Filter;
@@ -41,8 +43,6 @@ import static io.micronaut.http.HttpAttributes.URI_TEMPLATE;
 @Requires(property = WebMetricsPublisher.ENABLED, notEquals = FALSE)
 public class ClientRequestMetricRegistryFilter implements HttpClientFilter {
 
-    private static final String HOST_HEADER = "host";
-
     private final MeterRegistry meterRegistry;
 
     /**
@@ -64,18 +64,23 @@ public class ClientRequestMetricRegistryFilter implements HttpClientFilter {
                 start,
                 request.getMethod().toString(),
                 false,
-                resolveHost(request),
+                resolveServiceID(request),
                 true
         );
     }
 
     private String resolvePath(MutableHttpRequest<?> request) {
         Optional<String> route = request.getAttribute(URI_TEMPLATE, String.class);
-        return route.orElseGet(request::getPath);
+        // only include templated paths
+        return route.orElse(null);
     }
 
-    private String resolveHost(MutableHttpRequest<?> request) {
-        Optional<String> host = request.getHeaders().get(HOST_HEADER, String.class);
-        return host.orElse(request.getUri().getHost());
+    @SuppressWarnings("java:S2259") // false positive
+    private String resolveServiceID(MutableHttpRequest<?> request) {
+        String serviceId = request.getAttributes().get(HttpAttributes.SERVICE_ID.toString(), String.class).orElse(null);
+        if (StringUtils.isNotEmpty(serviceId) && serviceId.charAt(0) == '/') {
+            return "embedded-server";
+        }
+        return serviceId;
     }
 }

--- a/micrometer-core/src/main/java/io/micronaut/configuration/metrics/binder/web/ServerRequestMeterRegistryFilter.java
+++ b/micrometer-core/src/main/java/io/micronaut/configuration/metrics/binder/web/ServerRequestMeterRegistryFilter.java
@@ -49,6 +49,7 @@ import static io.micronaut.core.util.StringUtils.FALSE;
 public class ServerRequestMeterRegistryFilter implements HttpServerFilter {
 
     private static final String ATTRIBUTE_KEY = "micronaut.filter." + ServerRequestMeterRegistryFilter.class.getSimpleName();
+    private static final String UNMATCHED_URI = "UNMATCHED_URI";
     private final MeterRegistry meterRegistry;
 
     /**
@@ -64,8 +65,8 @@ public class ServerRequestMeterRegistryFilter implements HttpServerFilter {
             .map(UriRoute::getUriMatchTemplate)
             .map(UriMatchTemplate::toPathString);
 
-        return routeInfo.orElseGet(() -> request.getAttribute(HttpAttributes.URI_TEMPLATE).map(Object::toString)
-            .orElse(request.getUri().toString()));
+        return routeInfo.orElseGet(() -> request.getAttribute(HttpAttributes.URI_TEMPLATE, String.class)
+                        .orElse(UNMATCHED_URI));
     }
 
     /**

--- a/micrometer-core/src/test/groovy/io/micronaut/configuration/metrics/binder/web/HttpMetricsSpec.groovy
+++ b/micrometer-core/src/test/groovy/io/micronaut/configuration/metrics/binder/web/HttpMetricsSpec.groovy
@@ -1,20 +1,31 @@
 package io.micronaut.configuration.metrics.binder.web
 
 import groovy.transform.InheritConstructors
+import io.micrometer.common.lang.NonNull
 import io.micrometer.core.instrument.MeterRegistry
 import io.micrometer.core.instrument.Timer
 import io.micrometer.core.instrument.distribution.HistogramSnapshot
 import io.micrometer.core.instrument.search.MeterNotFoundException
 import io.micronaut.context.ApplicationContext
+import io.micronaut.core.util.CollectionUtils
 import io.micronaut.http.HttpResponse
 import io.micronaut.http.annotation.Controller
 import io.micronaut.http.annotation.Error
 import io.micronaut.http.annotation.Get
 import io.micronaut.http.client.annotation.Client
 import io.micronaut.http.client.exceptions.HttpClientResponseException
+import io.micronaut.http.uri.UriBuilder
 import io.micronaut.runtime.server.EmbeddedServer
+import io.micronaut.websocket.WebSocketBroadcaster
+import io.micronaut.websocket.WebSocketClient
+import io.micronaut.websocket.WebSocketSession
+import io.micronaut.websocket.annotation.*
+import org.reactivestreams.Publisher
+import reactor.core.publisher.Flux
 import spock.lang.Specification
 import spock.lang.Unroll
+
+import javax.validation.constraints.NotBlank
 
 import static io.micronaut.configuration.metrics.micrometer.MeterRegistryFactory.MICRONAUT_METRICS_BINDERS
 import static io.micronaut.configuration.metrics.micrometer.MeterRegistryFactory.MICRONAUT_METRICS_ENABLED
@@ -152,6 +163,36 @@ class HttpMetricsSpec extends Specification {
         (WebMetricsPublisher.ENABLED) | false
     }
 
+    void "test websocket"() {
+        when:
+        EmbeddedServer embeddedServer = ApplicationContext.run(EmbeddedServer, [(MICRONAUT_METRICS_ENABLED): true])
+        MeterRegistry registry = embeddedServer.getApplicationContext().getBean(MeterRegistry)
+        createWebSocketClient(embeddedServer.getApplicationContext(), embeddedServer.getPort(), "Travolta")
+
+        then:
+        registry.get(WebMetricsPublisher.METRIC_HTTP_SERVER_REQUESTS).tags('uri', '/ws/{username}').timer()
+    }
+
+    @ClientWebSocket
+    static abstract class TestWebSocketClient implements AutoCloseable {
+        abstract void send(@NonNull @NotBlank String message);
+
+        @OnMessage
+        void onMessage(String message) {}
+    }
+
+
+    private TestWebSocketClient createWebSocketClient(ApplicationContext context, int port, String username) {
+        WebSocketClient webSocketClient = context.getBean(WebSocketClient.class)
+        URI uri = UriBuilder.of("ws://localhost")
+                .port(port)
+                .path("ws")
+                .path("{username}")
+                .expand(CollectionUtils.mapOf("username", username))
+        Publisher<TestWebSocketClient> client = webSocketClient.connect(TestWebSocketClient.class, uri)
+        return Flux.from(client).blockFirst()
+    }
+
     @Client('/')
     static interface TestClient {
         @Get
@@ -206,6 +247,33 @@ class HttpMetricsSpec extends Specification {
         HttpResponse<?> myExceptionHandler() {
             return HttpResponse.badRequest()
         }
+    }
+
+    @ServerWebSocket("/ws/{username}")
+    static class TestWSController {
+
+        private final WebSocketBroadcaster broadcaster
+
+        @OnOpen
+        Publisher<String> onOpen(String username, WebSocketSession session) {
+            return broadcaster.broadcast(String.format("Joined %s!", username))
+        }
+
+        @OnMessage
+        Publisher<String> onMessage(
+                String username,
+                String message,
+                WebSocketSession session) {
+            return broadcaster.broadcast(String.format("[%s] %s", username, message))
+        }
+
+        @OnClose
+        Publisher<String> onClose(
+                String username,
+                WebSocketSession session) {
+            return broadcaster.broadcast(String.format("Leaving %s!", username))
+        }
+
     }
 
     @InheritConstructors

--- a/micrometer-core/src/test/groovy/io/micronaut/configuration/metrics/binder/web/HttpMetricsSpec.groovy
+++ b/micrometer-core/src/test/groovy/io/micronaut/configuration/metrics/binder/web/HttpMetricsSpec.groovy
@@ -73,7 +73,7 @@ class HttpMetricsSpec extends Specification {
         result == 'ok foo'
         registry.get(WebMetricsPublisher.METRIC_HTTP_CLIENT_REQUESTS).tags('uri', '/test-http-metrics/{id}').timer()
         registry.get(WebMetricsPublisher.METRIC_HTTP_SERVER_REQUESTS).tags('uri', '/test-http-metrics/{id}').timer()
-        registry.get(WebMetricsPublisher.METRIC_HTTP_CLIENT_REQUESTS).tags('host', 'localhost').timer()
+        registry.get(WebMetricsPublisher.METRIC_HTTP_CLIENT_REQUESTS).tags('serviceId', 'embedded-server').timer()
 
         when:
         registry.get(WebMetricsPublisher.METRIC_HTTP_SERVER_REQUESTS).tags('uri', '/test-http-metrics/foo').timer()


### PR DESCRIPTION
* Use service ID instead of host to identify clients
* Fallback to a fixed unmatched URI when template is not found 

Fixes #458 and Fixes #397