### PR TITLE
Stop using extra plugins in the micrometer-bom

### DIFF
--- a/buildSrc/src/main/groovy/io.micronaut.build.internal.micrometer-base.gradle
+++ b/buildSrc/src/main/groovy/io.micronaut.build.internal.micrometer-base.gradle
@@ -2,9 +2,6 @@ plugins {
     id 'io.micronaut.build.internal.base'
 }
 
-version projectVersion
-group 'io.micronaut.micrometer'
-
 repositories {
     maven { setUrl("https://s01.oss.sonatype.org/content/repositories/snapshots/") }
     mavenCentral()

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,5 @@
 projectVersion=5.0.0-SNAPSHOT
+projectGroup=io.micronaut.micrometer
 
 micronautSerializationVersion=1.3.2
 

--- a/micrometer-bom/build.gradle
+++ b/micrometer-bom/build.gradle
@@ -1,12 +1,3 @@
 plugins {
     id 'io.micronaut.build.internal.bom'
 }
-
-micronautBom {
-    excludeProject.set({ p ->
-        p.name == 'test-suite' ||
-        p.name == 'doc-examples' ||
-        p.path.contains('test-suite:') ||
-        p.path.contains('doc-examples:')
-    } as Spec<String>)
-}

--- a/micrometer-bom/build.gradle
+++ b/micrometer-bom/build.gradle
@@ -1,12 +1,12 @@
 plugins {
-    id 'io.micronaut.build.internal.micrometer-base'
     id 'io.micronaut.build.internal.bom'
 }
+
 micronautBom {
-    excludeProject.set({ p ->    
-        p.name == 'test-suite' || 
-        p.name == 'doc-examples' || 
-        p.path.contains('test-suite:') || 
+    excludeProject.set({ p ->
+        p.name == 'test-suite' ||
+        p.name == 'doc-examples' ||
+        p.path.contains('test-suite:') ||
         p.path.contains('doc-examples:')
     } as Spec<String>)
 }


### PR DESCRIPTION
This was causing the javadoc task to look for javadoc in the bom.

Then it couldn't find any, and would fail like so:

https://ge.micronaut.io/s/uvsi5oa6uiq6c/console-log