### PR TITLE
`@MetricOptions` to allow filtering `AbstractMethodTagger` beans to apply to metrics

### DIFF
--- a/micrometer-core/src/main/java/io/micronaut/configuration/metrics/annotation/MetricOptions.java
+++ b/micrometer-core/src/main/java/io/micronaut/configuration/metrics/annotation/MetricOptions.java
@@ -40,4 +40,9 @@ public @interface MetricOptions {
      * @return array of {@link io.micronaut.configuration.metrics.aggregator.AbstractMethodTagger} to apply to metrics for method
      */
     Class<? extends AbstractMethodTagger>[] taggers() default {};
+
+    /**
+     * @return whether to filter taggers using {@link #taggers()} array
+     */
+    boolean filterTaggers() default false;
 }

--- a/micrometer-core/src/main/java/io/micronaut/configuration/metrics/annotation/MetricOptions.java
+++ b/micrometer-core/src/main/java/io/micronaut/configuration/metrics/annotation/MetricOptions.java
@@ -25,7 +25,7 @@ import static java.lang.annotation.ElementType.METHOD;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 /**
- * Holds metadata about metric options
+ * Holds metadata about metric options to apply
  *
  * @author Haiden Rothwell
  * @since 5.6.0
@@ -34,7 +34,10 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 @Retention(RUNTIME)
 @Target({METHOD})
 public @interface MetricOptions {
-    // TODO if empty or null should this do nothing? no filtering happening unless something defined? but then
-    //  what if you really truly don't want anything applied?
+    /**
+     * TODO if empty or null should this do nothing? no filtering happening unless something defined? but then
+     *  what if you really truly don't want anything applied? Null is not an option for default, some secondary annotation value?
+     * @return array of {@link io.micronaut.configuration.metrics.aggregator.AbstractMethodTagger} to apply to metrics for method
+     */
     Class<? extends AbstractMethodTagger>[] taggers() default {};
 }

--- a/micrometer-core/src/main/java/io/micronaut/configuration/metrics/annotation/MetricOptions.java
+++ b/micrometer-core/src/main/java/io/micronaut/configuration/metrics/annotation/MetricOptions.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2017-2019 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.configuration.metrics.annotation;
+
+import io.micronaut.configuration.metrics.aggregator.AbstractMethodTagger;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Holds metadata about metric options
+ *
+ * @author Haiden Rothwell
+ * @since 5.6.0
+ */
+@Documented
+@Retention(RUNTIME)
+@Target({METHOD})
+public @interface MetricOptions {
+    // TODO if empty or null should this do nothing? no filtering happening unless something defined? but then
+    //  what if you really truly don't want anything applied?
+    Class<? extends AbstractMethodTagger>[] taggers() default {};
+}

--- a/micrometer-core/src/main/java/io/micronaut/configuration/metrics/annotation/MetricOptions.java
+++ b/micrometer-core/src/main/java/io/micronaut/configuration/metrics/annotation/MetricOptions.java
@@ -16,6 +16,7 @@
 package io.micronaut.configuration.metrics.annotation;
 
 import io.micronaut.configuration.metrics.aggregator.AbstractMethodTagger;
+import io.micronaut.core.annotation.Experimental;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
@@ -31,13 +32,13 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * @since 5.6.0
  */
 @Documented
+@Experimental
 @Retention(RUNTIME)
 @Target({METHOD})
 public @interface MetricOptions {
     /**
-     * TODO if empty or null should this do nothing? no filtering happening unless something defined? but then
-     *  what if you really truly don't want anything applied? Null is not an option for default, some secondary annotation value?
-     * @return array of {@link io.micronaut.configuration.metrics.aggregator.AbstractMethodTagger} to apply to metrics for method
+     * @return array of {@link io.micronaut.configuration.metrics.aggregator.AbstractMethodTagger} to apply to metrics for method.
+     * Only utilized for filtering if {@link #filterTaggers()} is true
      */
     Class<? extends AbstractMethodTagger>[] taggers() default {};
 

--- a/micrometer-core/src/main/java/io/micronaut/configuration/metrics/micrometer/intercept/CountedInterceptor.java
+++ b/micrometer-core/src/main/java/io/micronaut/configuration/metrics/micrometer/intercept/CountedInterceptor.java
@@ -151,13 +151,14 @@ public class CountedInterceptor implements MethodInterceptor<Object, Object> {
 
     private void doCount(AnnotationMetadata metadata, String metricName, @Nullable Throwable e, MethodInvocationContext<Object, Object> context) {
         List<Class<? extends AbstractMethodTagger>> taggers = Arrays.asList(metadata.classValues(MetricOptions.class, "taggers"));
+        boolean filter = metadata.booleanValue(MetricOptions.class, "filterTaggers").orElse(false);
         Counter.builder(metricName)
                 .tags(metadata.stringValues(Counted.class, "extraTags"))
                 .tags(
                     methodTaggers.isEmpty() ? Collections.emptyList() :
                         methodTaggers
                             .stream()
-                            .filter(t -> taggers.isEmpty() || taggers.contains(t.getClass()))
+                            .filter(t -> !filter || taggers.contains(t.getClass()))
                             .flatMap(t -> t.getTags(context).stream())
                             .toList()
                 )

--- a/micrometer-core/src/main/java/io/micronaut/configuration/metrics/micrometer/intercept/TimedInterceptor.java
+++ b/micrometer-core/src/main/java/io/micronaut/configuration/metrics/micrometer/intercept/TimedInterceptor.java
@@ -25,6 +25,7 @@ import io.micronaut.aop.InterceptorBean;
 import io.micronaut.aop.MethodInterceptor;
 import io.micronaut.aop.MethodInvocationContext;
 import io.micronaut.configuration.metrics.aggregator.AbstractMethodTagger;
+import io.micronaut.configuration.metrics.annotation.MetricOptions;
 import io.micronaut.configuration.metrics.annotation.RequiresMetrics;
 import io.micronaut.core.annotation.AnnotationMetadata;
 import io.micronaut.core.annotation.AnnotationValue;
@@ -43,6 +44,7 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
@@ -212,6 +214,7 @@ public class TimedInterceptor implements MethodInterceptor<Object, Object> {
         try {
             final String description = metadata.stringValue("description").orElse(null);
             final String[] tags = metadata.stringValues("extraTags");
+            List<Class<? extends AbstractMethodTagger>> taggers = Arrays.asList(context.getAnnotationMetadata().classValues(MetricOptions.class, "taggers"));
             final double[] percentiles = metadata.doubleValues("percentiles");
             final boolean histogram = metadata.isTrue("histogram");
             final Timer timer = Timer.builder(metricName)
@@ -221,7 +224,8 @@ public class TimedInterceptor implements MethodInterceptor<Object, Object> {
                         methodTaggers.isEmpty() ? Collections.emptyList() :
                             methodTaggers
                             .stream()
-                            .flatMap(b -> b.getTags(context).stream())
+                                .filter(t -> taggers.isEmpty() || taggers.contains(t.getClass()))
+                                .flatMap(b -> b.getTags(context).stream())
                             .toList()
                     )
                     .tags(EXCEPTION_TAG, exceptionClass)

--- a/micrometer-core/src/main/java/io/micronaut/configuration/metrics/micrometer/intercept/TimedInterceptor.java
+++ b/micrometer-core/src/main/java/io/micronaut/configuration/metrics/micrometer/intercept/TimedInterceptor.java
@@ -214,7 +214,9 @@ public class TimedInterceptor implements MethodInterceptor<Object, Object> {
         try {
             final String description = metadata.stringValue("description").orElse(null);
             final String[] tags = metadata.stringValues("extraTags");
-            List<Class<? extends AbstractMethodTagger>> taggers = Arrays.asList(context.getAnnotationMetadata().classValues(MetricOptions.class, "taggers"));
+            final AnnotationMetadata annotationMetadata = context.getAnnotationMetadata();
+            final List<Class<? extends AbstractMethodTagger>> taggers = Arrays.asList(annotationMetadata.classValues(MetricOptions.class, "taggers"));
+            final boolean filter = annotationMetadata.booleanValue(MetricOptions.class, "filterTaggers").orElse(false);
             final double[] percentiles = metadata.doubleValues("percentiles");
             final boolean histogram = metadata.isTrue("histogram");
             final Timer timer = Timer.builder(metricName)
@@ -224,7 +226,7 @@ public class TimedInterceptor implements MethodInterceptor<Object, Object> {
                         methodTaggers.isEmpty() ? Collections.emptyList() :
                             methodTaggers
                             .stream()
-                                .filter(t -> taggers.isEmpty() || taggers.contains(t.getClass()))
+                                .filter(t -> !filter || taggers.contains(t.getClass()))
                                 .flatMap(b -> b.getTags(context).stream())
                             .toList()
                     )

--- a/micrometer-core/src/test/java/io/micronaut/configuration/metrics/annotation/CountedTarget.java
+++ b/micrometer-core/src/test/java/io/micronaut/configuration/metrics/annotation/CountedTarget.java
@@ -17,7 +17,7 @@ public class CountedTarget {
     }
 
     @Counted("counted.test.maxWithOptions.blocking")
-    @MetricOptions(taggers = {MethodTaggerExample.class})
+    @MetricOptions(taggers = {MethodTaggerExample.class}, filterTaggers = true)
     Integer maxWithOptions(int a, int b) {
         return Math.max(a, b);
     }

--- a/micrometer-core/src/test/java/io/micronaut/configuration/metrics/annotation/CountedTarget.java
+++ b/micrometer-core/src/test/java/io/micronaut/configuration/metrics/annotation/CountedTarget.java
@@ -1,6 +1,7 @@
 package io.micronaut.configuration.metrics.annotation;
 
 import io.micrometer.core.annotation.Counted;
+import io.micronaut.configuration.metrics.aggregator.MethodTaggerExample;
 import jakarta.inject.Singleton;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -12,6 +13,12 @@ public class CountedTarget {
 
     @Counted("counted.test.max.blocking")
     Integer max(int a, int b) {
+        return Math.max(a, b);
+    }
+
+    @Counted("counted.test.maxWithOptions.blocking")
+    @MetricOptions(taggers = {MethodTaggerExample.class})
+    Integer maxWithOptions(int a, int b) {
         return Math.max(a, b);
     }
 

--- a/micrometer-core/src/test/java/io/micronaut/configuration/metrics/annotation/TimedTarget.java
+++ b/micrometer-core/src/test/java/io/micronaut/configuration/metrics/annotation/TimedTarget.java
@@ -17,7 +17,7 @@ class TimedTarget {
     }
 
     @Timed("timed.test.maxWithOptions.blocking")
-    @MetricOptions(taggers = {MethodTaggerExample.class})
+    @MetricOptions(taggers = {MethodTaggerExample.class}, filterTaggers = true)
     Integer maxWithOptions(int a, int b) {
         return Math.max(a, b);
     }

--- a/micrometer-core/src/test/java/io/micronaut/configuration/metrics/annotation/TimedTarget.java
+++ b/micrometer-core/src/test/java/io/micronaut/configuration/metrics/annotation/TimedTarget.java
@@ -1,6 +1,7 @@
 package io.micronaut.configuration.metrics.annotation;
 
 import io.micrometer.core.annotation.Timed;
+import io.micronaut.configuration.metrics.aggregator.MethodTaggerExample;
 import jakarta.inject.Singleton;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -12,6 +13,12 @@ class TimedTarget {
 
     @Timed("timed.test.max.blocking")
     Integer max(int a, int b) {
+        return Math.max(a, b);
+    }
+
+    @Timed("timed.test.maxWithOptions.blocking")
+    @MetricOptions(taggers = {MethodTaggerExample.class})
+    Integer maxWithOptions(int a, int b) {
         return Math.max(a, b);
     }
 


### PR DESCRIPTION
Follow up to #753 

- New annotation `MetricOptions` to hold metadata for additional information that might be used in building metrics
  - includes list of `taggers` for class types to apply to the published metric. 
  - **Note:** I was unsure on how to best implement a "don't filter any beans, apply everything" so I currently opted for treating an empty array as no filtering, but I don't think this should be a final solution. Looking for more input about it. 
- Add new tests showing filtering is applied correctly
- Was planning on updating documentation after input on how to go forward with the issue listed above and as a `TODO` 