### PR TITLE
Reorder when `AbstractMethodTagger` tags are added to metrics

### DIFF
--- a/micrometer-core/src/main/java/io/micronaut/configuration/metrics/micrometer/intercept/CountedInterceptor.java
+++ b/micrometer-core/src/main/java/io/micronaut/configuration/metrics/micrometer/intercept/CountedInterceptor.java
@@ -153,7 +153,6 @@ public class CountedInterceptor implements MethodInterceptor<Object, Object> {
         List<Class<? extends AbstractMethodTagger>> taggers = Arrays.asList(metadata.classValues(MetricOptions.class, "taggers"));
         boolean filter = metadata.booleanValue(MetricOptions.class, "filterTaggers").orElse(false);
         Counter.builder(metricName)
-                .tags(metadata.stringValues(Counted.class, "extraTags"))
                 .tags(
                     methodTaggers.isEmpty() ? Collections.emptyList() :
                         methodTaggers
@@ -162,6 +161,7 @@ public class CountedInterceptor implements MethodInterceptor<Object, Object> {
                             .flatMap(t -> t.getTags(context).stream())
                             .toList()
                 )
+                .tags(metadata.stringValues(Counted.class, "extraTags"))
                 .description(metadata.stringValue(Counted.class, "description").orElse(null))
                 .tag(EXCEPTION_TAG, e != null ? e.getClass().getSimpleName() : "none")
                 .tag(RESULT_TAG, e != null ? "failure" : "success")

--- a/micrometer-core/src/main/java/io/micronaut/configuration/metrics/micrometer/intercept/TimedInterceptor.java
+++ b/micrometer-core/src/main/java/io/micronaut/configuration/metrics/micrometer/intercept/TimedInterceptor.java
@@ -221,7 +221,6 @@ public class TimedInterceptor implements MethodInterceptor<Object, Object> {
             final boolean histogram = metadata.isTrue("histogram");
             final Timer timer = Timer.builder(metricName)
                     .description(description)
-                    .tags(tags)
                     .tags(
                         methodTaggers.isEmpty() ? Collections.emptyList() :
                             methodTaggers
@@ -230,6 +229,7 @@ public class TimedInterceptor implements MethodInterceptor<Object, Object> {
                                 .flatMap(b -> b.getTags(context).stream())
                             .toList()
                     )
+                    .tags(tags)
                     .tags(EXCEPTION_TAG, exceptionClass)
                     .publishPercentileHistogram(histogram)
                     .publishPercentiles(percentiles)

--- a/micrometer-core/src/test/java/io/micronaut/configuration/metrics/annotation/CountedTarget.java
+++ b/micrometer-core/src/test/java/io/micronaut/configuration/metrics/annotation/CountedTarget.java
@@ -16,6 +16,11 @@ public class CountedTarget {
         return Math.max(a, b);
     }
 
+    @Counted(value = "counted.test.maxWithExtraTags.blocking", extraTags = {"method", "CountedTarget.maxWithExtraTags"})
+    Integer maxWithExtraTags(int a, int b) {
+        return Math.max(a, b);
+    }
+
     @Counted("counted.test.maxWithOptions.blocking")
     @MetricOptions(taggers = {MethodTaggerExample.class}, filterTaggers = true)
     Integer maxWithOptions(int a, int b) {

--- a/micrometer-core/src/test/java/io/micronaut/configuration/metrics/annotation/TimedTarget.java
+++ b/micrometer-core/src/test/java/io/micronaut/configuration/metrics/annotation/TimedTarget.java
@@ -1,5 +1,6 @@
 package io.micronaut.configuration.metrics.annotation;
 
+import io.micrometer.core.annotation.Counted;
 import io.micrometer.core.annotation.Timed;
 import io.micronaut.configuration.metrics.aggregator.MethodTaggerExample;
 import jakarta.inject.Singleton;
@@ -13,6 +14,11 @@ class TimedTarget {
 
     @Timed("timed.test.max.blocking")
     Integer max(int a, int b) {
+        return Math.max(a, b);
+    }
+
+    @Timed(value = "timed.test.maxWithExtraTags.blocking", extraTags = {"method", "TimedTarget.maxWithExtraTags"})
+    Integer maxWithExtraTags(int a, int b) {
         return Math.max(a, b);
     }
 


### PR DESCRIPTION
Follow-up PR after #753 and #764 were released

If a user defines the same tag key in their annotation, that should likely take priority over any tags that may have been applied via `AbstractMethodTagger` beans. This can be accomplished by flipping the order of applying `.tags(...)` 

Also includes a little bit of test formatting (my indents appeared off from the existing, didn't catch it last time) 