### PR TITLE
inject MeterRegistry inside filters as a provider

### DIFF
--- a/micrometer-core/src/main/java/io/micronaut/configuration/metrics/binder/web/ClientRequestMetricRegistryFilter.java
+++ b/micrometer-core/src/main/java/io/micronaut/configuration/metrics/binder/web/ClientRequestMetricRegistryFilter.java
@@ -25,6 +25,7 @@ import io.micronaut.http.MutableHttpRequest;
 import io.micronaut.http.annotation.Filter;
 import io.micronaut.http.filter.ClientFilterChain;
 import io.micronaut.http.filter.HttpClientFilter;
+import jakarta.inject.Provider;
 import org.reactivestreams.Publisher;
 
 import java.util.Optional;
@@ -43,15 +44,14 @@ import static io.micronaut.http.HttpAttributes.URI_TEMPLATE;
 @Requires(property = WebMetricsPublisher.ENABLED, notEquals = FALSE)
 @Requires(condition = WebMetricsClientCondition.class)
 public class ClientRequestMetricRegistryFilter implements HttpClientFilter {
-    private static final String HOST_HEADER = "host";
 
-    private final MeterRegistry meterRegistry;
+    private final Provider<MeterRegistry> meterRegistryProvider;
 
     /**
-     * @param meterRegistry The metrics registry
+     * @param meterRegistryProvider the meter registry provider
      */
-    public ClientRequestMetricRegistryFilter(MeterRegistry meterRegistry) {
-        this.meterRegistry = meterRegistry;
+    public ClientRequestMetricRegistryFilter(Provider<MeterRegistry> meterRegistryProvider) {
+        this.meterRegistryProvider = meterRegistryProvider;
     }
 
     @Override
@@ -61,7 +61,7 @@ public class ClientRequestMetricRegistryFilter implements HttpClientFilter {
 
         return new WebMetricsPublisher<>(
                 responsePublisher,
-                meterRegistry,
+                meterRegistryProvider.get(),
                 resolvePath(request),
                 start,
                 request.getMethod().toString(),

--- a/micrometer-core/src/main/java/io/micronaut/configuration/metrics/binder/web/ServerRequestMeterRegistryFilter.java
+++ b/micrometer-core/src/main/java/io/micronaut/configuration/metrics/binder/web/ServerRequestMeterRegistryFilter.java
@@ -28,6 +28,7 @@ import io.micronaut.http.filter.ServerFilterChain;
 import io.micronaut.http.uri.UriMatchTemplate;
 import io.micronaut.web.router.UriRouteInfo;
 import io.micronaut.web.router.UriRouteMatch;
+import jakarta.inject.Provider;
 import org.reactivestreams.Publisher;
 import java.util.Optional;
 import static io.micronaut.core.util.StringUtils.FALSE;
@@ -50,16 +51,16 @@ public class ServerRequestMeterRegistryFilter implements HttpServerFilter {
 
     private static final String ATTRIBUTE_KEY = "micronaut.filter." + ServerRequestMeterRegistryFilter.class.getSimpleName();
     private static final String UNMATCHED_URI = "UNMATCHED_URI";
-    private final MeterRegistry meterRegistry;
+    private final Provider<MeterRegistry> meterRegistryProvider;
 
     @Value("${" + WebMetricsPublisher.CLIENT_ERROR_URIS_ENABLED + ":true}")
     private boolean reportClientErrorURIs;
 
     /**
-     * @param meterRegistry the meter registry
+     * @param meterRegistryProvider the meter registry provider
      */
-    public ServerRequestMeterRegistryFilter(MeterRegistry meterRegistry) {
-        this.meterRegistry = meterRegistry;
+    public ServerRequestMeterRegistryFilter(Provider<MeterRegistry> meterRegistryProvider) {
+        this.meterRegistryProvider = meterRegistryProvider;
     }
 
     private String resolvePath(HttpRequest<?> request) {
@@ -83,7 +84,7 @@ public class ServerRequestMeterRegistryFilter implements HttpServerFilter {
         }
         return new WebMetricsPublisher<>(
             responsePublisher,
-            meterRegistry,
+            meterRegistryProvider.get(),
             path,
             start,
             request.getMethod().toString(),


### PR DESCRIPTION
MeterRegistry should be injected as Provider. That will ensure that Meter registry is closed before the clients. This is needed because meter registry could use an http client for sending metrics.