### PR TITLE
Micrometer update to latest versions

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,8 +18,8 @@ hdr-histogram = '2.2.2'
 
 micronaut-aws = "4.6.0"
 micronaut-cache = "4.3.0"
-micronaut-logging = "1.2.2"
 micronaut-grpc = "4.6.0"
+micronaut-logging = "1.3.0"
 micronaut-r2dbc = "5.5.0"
 micronaut-rxjava2 = "2.4.0"
 micronaut-reactor = '3.4.1'

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,8 +18,8 @@ hdr-histogram = '2.2.2'
 
 micronaut-aws = "4.6.0"
 micronaut-cache = "4.3.0"
-micronaut-grpc = "4.5.0"
 micronaut-logging = "1.2.2"
+micronaut-grpc = "4.6.0"
 micronaut-r2dbc = "5.5.0"
 micronaut-rxjava2 = "2.4.0"
 micronaut-reactor = '3.4.1'

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,8 +2,8 @@
 micronaut-platform = "4.5.1"
 micronaut = "4.6.0"
 micronaut-docs = "2.0.0"
-micronaut-test = "4.2.0"
 micronaut-gradle-plugin = "4.4.2"
+micronaut-test = "4.4.0"
 groovy = "4.0.15"
 spock = "2.3-groovy-4.0"
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 micronaut-platform = "4.5.1"
-micronaut = "4.5.4"
+micronaut = "4.6.0"
 micronaut-docs = "2.0.0"
 micronaut-test = "4.2.0"
 micronaut-gradle-plugin = "4.4.2"


### PR DESCRIPTION
@yawkat @dstepanov do either of you know what have changed: 

This test now fails: 

```
./gradlew :micronaut-micrometer-core:test --tests "io.micronaut.configuration.metrics.management.endpoint.FilteredMetricsEndpointSpec.warm up the server"
```

This returns `Hello World`
```
        @Get("/filtered/hello/{name}")
        Mono<String> hello(@NotBlank String name) {
            return Mono.just('Hello ' + name.capitalize())
        }
```

However, this now returns `[Hello World]`. Have we changed the way we manage `Single`?

```
        @Timed
        @Counted
        @Get("/filtered/rxjava2/{name}")
        Single<String> rxjava(@NotBlank String name) {
            return Single.just('Hello ' + name.capitalize())
        }
```