### PR TITLE
update to Micrometer 1.13.3 and micronaut core 4.6.x

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,7 +8,7 @@ groovy = "4.0.15"
 spock = "2.3-groovy-4.0"
 
 managed-metrics-core = '4.2.26'
-managed-micrometer = '1.13.3'
+managed-micrometer = '1.12.6'
 managed-micrometer-tracing = '1.3.3'
 managed-new-relic-registry = '0.10.0'
 reflections = '0.10.2'

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 micronaut-platform = "4.5.1"
-micronaut = "4.6.0"
+micronaut = "4.6.1"
 micronaut-docs = "2.0.0"
 micronaut-gradle-plugin = "4.4.2"
 micronaut-test = "4.4.0"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -23,7 +23,7 @@ micronaut-logging = "1.3.0"
 micronaut-r2dbc = "5.5.0"
 micronaut-rxjava2 = "2.4.0"
 micronaut-reactor = '3.4.1'
-micronaut-serde = "2.10.2"
+micronaut-serde = "2.11.0"
 micronaut-sql = "5.7.0"
 micronaut-validation = "4.6.1"
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,8 +18,8 @@ hdr-histogram = '2.2.2'
 
 micronaut-aws = "4.6.0"
 micronaut-cache = "4.3.0"
-micronaut-logging = "1.2.2"
 micronaut-grpc = "4.6.0"
+micronaut-logging = "1.3.0"
 micronaut-r2dbc = "5.5.0"
 micronaut-rxjava2 = "2.4.0"
 micronaut-reactor = '3.4.1'

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,7 +8,7 @@ groovy = "4.0.15"
 spock = "2.3-groovy-4.0"
 
 managed-metrics-core = '4.2.26'
-managed-micrometer = '1.12.6'
+managed-micrometer = '1.13.3'
 managed-micrometer-tracing = '1.3.3'
 managed-new-relic-registry = '0.10.0'
 reflections = '0.10.2'

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,8 +18,8 @@ hdr-histogram = '2.2.2'
 
 micronaut-aws = "4.6.0"
 micronaut-cache = "4.3.0"
-micronaut-grpc = "4.5.0"
 micronaut-logging = "1.2.2"
+micronaut-grpc = "4.6.0"
 micronaut-r2dbc = "5.5.0"
 micronaut-rxjava2 = "2.4.0"
 micronaut-reactor = '3.4.1'

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,8 +2,8 @@
 micronaut-platform = "4.5.1"
 micronaut = "4.6.0"
 micronaut-docs = "2.0.0"
-micronaut-test = "4.2.0"
 micronaut-gradle-plugin = "4.4.2"
+micronaut-test = "4.4.0"
 groovy = "4.0.15"
 spock = "2.3-groovy-4.0"
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 micronaut-platform = "4.5.1"
-micronaut = "4.5.4"
+micronaut = "4.6.0"
 micronaut-docs = "2.0.0"
 micronaut-test = "4.2.0"
 micronaut-gradle-plugin = "4.4.2"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -25,7 +25,7 @@ micronaut-rxjava2 = "2.4.0"
 micronaut-reactor = '3.4.1'
 micronaut-serde = "2.11.0"
 micronaut-sql = "5.7.0"
-micronaut-validation = "4.6.1"
+micronaut-validation = "4.7.0"
 
 [libraries]
 # Core

--- a/micrometer-bom/build.gradle
+++ b/micrometer-bom/build.gradle
@@ -5,9 +5,9 @@ plugins {
 micronautBom {
     suppressions {
         dependencies.addAll([
-                // bomCheck fails because io.micrometer:docs is in the bom, but isn't a published artifact.
-                // See: https://github.com/micrometer-metrics/micrometer/issues/4606
-                "io.micrometer:docs:${libs.versions.managed.micrometer.asProvider().get()}",
+                // bomCheck fails because io.micrometer:concurrency-tests is in the bom, but isn't a published artifact.
+                // See: https://github.com/micrometer-metrics/micrometer/issues/5395
+                "io.micrometer:concurrency-tests:${libs.versions.managed.micrometer.asProvider().get()}",
         ])
     }
 }

--- a/micrometer-core/src/test/groovy/io/micronaut/configuration/metrics/binder/web/HttpMetricsSpec.groovy
+++ b/micrometer-core/src/test/groovy/io/micronaut/configuration/metrics/binder/web/HttpMetricsSpec.groovy
@@ -343,7 +343,7 @@ class HttpMetricsSpec extends Specification {
 
         @Get("/test-http-metrics/throwable")
         HttpResponse throwable() {
-            throw new RuntimeException("error")
+            throw new CustomRuntimeException("error")
         }
 
         @Get("/test-http-metrics/exception-handling")
@@ -355,6 +355,10 @@ class HttpMetricsSpec extends Specification {
         HttpResponse<?> myExceptionHandler() {
             return HttpResponse.badRequest()
         }
+    }
+
+    static class CustomRuntimeException extends RuntimeException {
+
     }
 
     @ServerWebSocket("/ws/{username}")

--- a/micrometer-registry-prometheus/src/main/java/io/micronaut/configuration/metrics/micrometer/prometheus/PrometheusMeterRegistryFactory.java
+++ b/micrometer-registry-prometheus/src/main/java/io/micronaut/configuration/metrics/micrometer/prometheus/PrometheusMeterRegistryFactory.java
@@ -15,7 +15,7 @@
  */
 package io.micronaut.configuration.metrics.micrometer.prometheus;
 
-import io.micrometer.prometheus.PrometheusMeterRegistry;
+import io.micrometer.prometheusmetrics.PrometheusMeterRegistry;
 import io.micronaut.configuration.metrics.micrometer.ExportConfigurationProperties;
 import io.micronaut.context.annotation.Factory;
 import jakarta.inject.Singleton;

--- a/micrometer-registry-prometheus/src/main/java/io/micronaut/configuration/metrics/micrometer/prometheus/management/PrometheusEndpoint.java
+++ b/micrometer-registry-prometheus/src/main/java/io/micronaut/configuration/metrics/micrometer/prometheus/management/PrometheusEndpoint.java
@@ -15,7 +15,7 @@
  */
 package io.micronaut.configuration.metrics.micrometer.prometheus.management;
 
-import io.micrometer.prometheus.PrometheusMeterRegistry;
+import io.micrometer.prometheusmetrics.PrometheusMeterRegistry;
 import io.micronaut.management.endpoint.annotation.Endpoint;
 import io.micronaut.management.endpoint.annotation.Read;
 

--- a/micrometer-registry-prometheus/src/test/groovy/io/micronaut/configuration/metrics/micrometer/prometheus/PrometheusMeterRegistryFactorySpec.groovy
+++ b/micrometer-registry-prometheus/src/test/groovy/io/micronaut/configuration/metrics/micrometer/prometheus/PrometheusMeterRegistryFactorySpec.groovy
@@ -2,7 +2,7 @@ package io.micronaut.configuration.metrics.micrometer.prometheus
 
 import io.micrometer.core.instrument.MeterRegistry
 import io.micrometer.core.instrument.composite.CompositeMeterRegistry
-import io.micrometer.prometheus.PrometheusMeterRegistry
+import io.micrometer.prometheusmetrics.PrometheusMeterRegistry
 import io.micronaut.context.ApplicationContext
 import spock.lang.Specification
 import spock.lang.Unroll


### PR DESCRIPTION
- Micrometer 1.13.3. See: [1.13 Migration Guide](https://github.com/micrometer-metrics/micrometer/wiki/1.13-Migration-Guide)

## Micronaut
- Micronaut Core 4.6.1
- Micronaut Test 4.4.0
- Micronaut Logging 1.3.0
- Micronaut gRPC 4.6.0
- Micronaut Serde 2.11.0
- Micronaut Validation 4.7.0
