### PR TITLE
order and sort`AbstractMethodTagger` before applying Tags

### DIFF
--- a/micrometer-core/src/main/java/io/micronaut/configuration/metrics/aggregator/AbstractMethodTagger.java
+++ b/micrometer-core/src/main/java/io/micronaut/configuration/metrics/aggregator/AbstractMethodTagger.java
@@ -19,6 +19,7 @@ import io.micrometer.core.instrument.Tag;
 import io.micronaut.aop.MethodInvocationContext;
 import io.micronaut.core.annotation.Indexed;
 import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.order.Ordered;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -32,7 +33,8 @@ import java.util.List;
  * @since 5.5.0
  */
 @Indexed(AbstractMethodTagger.class)
-public abstract class AbstractMethodTagger {
+public abstract class AbstractMethodTagger implements Ordered, Comparable<AbstractMethodTagger> {
+
     private static final Logger LOGGER = LoggerFactory.getLogger(AbstractMethodTagger.class);
 
     private final Class<? extends AbstractMethodTagger> implClass = this.getClass();
@@ -52,5 +54,10 @@ public abstract class AbstractMethodTagger {
             LOGGER.error("{} returned null list of tags and will not include additional tags on metric", implClass);
             return Collections.emptyList();
         }
+    }
+
+    @Override
+    public int compareTo(AbstractMethodTagger o) {
+        return Integer.compare(this.getOrder(), o.getOrder());
     }
 }

--- a/micrometer-core/src/main/java/io/micronaut/configuration/metrics/aggregator/AbstractMethodTagger.java
+++ b/micrometer-core/src/main/java/io/micronaut/configuration/metrics/aggregator/AbstractMethodTagger.java
@@ -33,7 +33,7 @@ import java.util.List;
  * @since 5.5.0
  */
 @Indexed(AbstractMethodTagger.class)
-public abstract class AbstractMethodTagger implements Ordered, Comparable<AbstractMethodTagger> {
+public abstract class AbstractMethodTagger implements Ordered {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(AbstractMethodTagger.class);
 
@@ -54,10 +54,5 @@ public abstract class AbstractMethodTagger implements Ordered, Comparable<Abstra
             LOGGER.error("{} returned null list of tags and will not include additional tags on metric", implClass);
             return Collections.emptyList();
         }
-    }
-
-    @Override
-    public int compareTo(AbstractMethodTagger o) {
-        return Integer.compare(this.getOrder(), o.getOrder());
     }
 }

--- a/micrometer-core/src/main/java/io/micronaut/configuration/metrics/micrometer/intercept/CountedInterceptor.java
+++ b/micrometer-core/src/main/java/io/micronaut/configuration/metrics/micrometer/intercept/CountedInterceptor.java
@@ -157,6 +157,7 @@ public class CountedInterceptor implements MethodInterceptor<Object, Object> {
                     methodTaggers.isEmpty() ? Collections.emptyList() :
                         methodTaggers
                             .stream()
+                            .sorted()
                             .filter(t -> !filter || taggers.contains(t.getClass()))
                             .flatMap(t -> t.getTags(context).stream())
                             .toList()

--- a/micrometer-core/src/main/java/io/micronaut/configuration/metrics/micrometer/intercept/CountedInterceptor.java
+++ b/micrometer-core/src/main/java/io/micronaut/configuration/metrics/micrometer/intercept/CountedInterceptor.java
@@ -29,6 +29,7 @@ import io.micronaut.core.annotation.AnnotationMetadata;
 import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.async.publisher.Publishers;
 import io.micronaut.core.convert.ConversionService;
+import io.micronaut.core.order.OrderUtil;
 import io.micronaut.core.util.StringUtils;
 import jakarta.inject.Inject;
 import org.reactivestreams.Publisher;
@@ -157,7 +158,7 @@ public class CountedInterceptor implements MethodInterceptor<Object, Object> {
                     methodTaggers.isEmpty() ? Collections.emptyList() :
                         methodTaggers
                             .stream()
-                            .sorted()
+                            .sorted(OrderUtil.ORDERED_COMPARATOR)
                             .filter(t -> !filter || taggers.contains(t.getClass()))
                             .flatMap(t -> t.getTags(context).stream())
                             .toList()

--- a/micrometer-core/src/main/java/io/micronaut/configuration/metrics/micrometer/intercept/TimedInterceptor.java
+++ b/micrometer-core/src/main/java/io/micronaut/configuration/metrics/micrometer/intercept/TimedInterceptor.java
@@ -32,6 +32,7 @@ import io.micronaut.core.annotation.AnnotationValue;
 import io.micronaut.core.annotation.TypeHint;
 import io.micronaut.core.async.publisher.Publishers;
 import io.micronaut.core.convert.ConversionService;
+import io.micronaut.core.order.OrderUtil;
 import io.micronaut.core.util.CollectionUtils;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
@@ -225,7 +226,7 @@ public class TimedInterceptor implements MethodInterceptor<Object, Object> {
                         methodTaggers.isEmpty() ? Collections.emptyList() :
                             methodTaggers
                             .stream()
-                                .sorted()
+                                .sorted(OrderUtil.ORDERED_COMPARATOR)
                                 .filter(t -> !filter || taggers.contains(t.getClass()))
                                 .flatMap(b -> b.getTags(context).stream())
                             .toList()

--- a/micrometer-core/src/main/java/io/micronaut/configuration/metrics/micrometer/intercept/TimedInterceptor.java
+++ b/micrometer-core/src/main/java/io/micronaut/configuration/metrics/micrometer/intercept/TimedInterceptor.java
@@ -225,6 +225,7 @@ public class TimedInterceptor implements MethodInterceptor<Object, Object> {
                         methodTaggers.isEmpty() ? Collections.emptyList() :
                             methodTaggers
                             .stream()
+                                .sorted()
                                 .filter(t -> !filter || taggers.contains(t.getClass()))
                                 .flatMap(b -> b.getTags(context).stream())
                             .toList()

--- a/micrometer-core/src/test/groovy/io/micronaut/configuration/metrics/annotation/CountedAnnotationSpec.groovy
+++ b/micrometer-core/src/test/groovy/io/micronaut/configuration/metrics/annotation/CountedAnnotationSpec.groovy
@@ -131,4 +131,28 @@ class CountedAnnotationSpec extends Specification {
         cleanup:
         ctx.close()
     }
+
+    void "filters are applied in order"(){
+        given:
+        ApplicationContext ctx = ApplicationContext.run()
+        CountedTarget cc = ctx.getBean(CountedTarget)
+        MeterRegistry registry = ctx.getBean(MeterRegistry)
+
+        when:
+        Integer result = cc.max(4, 10)
+        registry.get("counted.test.max.blocking").tags("ordered", "1", "parameters", "a b").timer()
+
+        then:
+        thrown(MeterNotFoundException)
+
+        when:
+        def counter = registry.get("counted.test.max.blocking").tags("ordered", "2", "parameters", "a b").counter()
+
+        then:
+        result == 10
+        counter.count() == 1
+
+        cleanup:
+        ctx.close()
+    }
 }

--- a/micrometer-core/src/test/groovy/io/micronaut/configuration/metrics/annotation/CountedAnnotationSpec.groovy
+++ b/micrometer-core/src/test/groovy/io/micronaut/configuration/metrics/annotation/CountedAnnotationSpec.groovy
@@ -132,7 +132,7 @@ class CountedAnnotationSpec extends Specification {
         ctx.close()
     }
 
-    void "filters are applied in order"(){
+    void "taggers are applied in order"(){
         given:
         ApplicationContext ctx = ApplicationContext.run()
         CountedTarget cc = ctx.getBean(CountedTarget)

--- a/micrometer-core/src/test/groovy/io/micronaut/configuration/metrics/annotation/TimeAnnotationSpec.groovy
+++ b/micrometer-core/src/test/groovy/io/micronaut/configuration/metrics/annotation/TimeAnnotationSpec.groovy
@@ -145,7 +145,7 @@ class TimeAnnotationSpec extends Specification {
         ctx.close()
     }
 
-    void "filters are applied in order"(){
+    void "taggers are applied in order"(){
         given:
         ApplicationContext ctx = ApplicationContext.run()
         TimedTarget tt = ctx.getBean(TimedTarget)

--- a/micrometer-core/src/test/java/io/micronaut/configuration/metrics/aggregator/OrderedMethodTagger.java
+++ b/micrometer-core/src/test/java/io/micronaut/configuration/metrics/aggregator/OrderedMethodTagger.java
@@ -1,0 +1,20 @@
+package io.micronaut.configuration.metrics.aggregator;
+
+import io.micrometer.core.instrument.Tag;
+import io.micronaut.aop.MethodInvocationContext;
+import jakarta.inject.Singleton;
+
+import java.util.List;
+
+@Singleton
+public class OrderedMethodTagger extends AbstractMethodTagger{
+    @Override
+    public int getOrder() {
+        return 1;
+    }
+
+    @Override
+    public List<Tag> buildTags(MethodInvocationContext<Object, Object> context) {
+        return List.of(Tag.of("ordered", String.valueOf(getOrder())));
+    }
+}

--- a/micrometer-core/src/test/java/io/micronaut/configuration/metrics/aggregator/OrderedMethodTagger2.java
+++ b/micrometer-core/src/test/java/io/micronaut/configuration/metrics/aggregator/OrderedMethodTagger2.java
@@ -1,0 +1,20 @@
+package io.micronaut.configuration.metrics.aggregator;
+
+import io.micrometer.core.instrument.Tag;
+import io.micronaut.aop.MethodInvocationContext;
+import jakarta.inject.Singleton;
+
+import java.util.List;
+
+@Singleton
+public class OrderedMethodTagger2 extends AbstractMethodTagger{
+    @Override
+    public int getOrder() {
+        return 2;
+    }
+
+    @Override
+    public List<Tag> buildTags(MethodInvocationContext<Object, Object> context) {
+        return List.of(Tag.of("ordered", String.valueOf(getOrder())));
+    }
+}


### PR DESCRIPTION
A use case might be that multiple taggers might use the same tag name, when determining which takes precedence in those situations felt like some sort of order / sorting would be needed 