### PR TITLE
Favor passed HTTP response over exception for error metrics

### DIFF
--- a/micrometer-core/src/main/java/io/micronaut/configuration/metrics/binder/web/ClientMetricsFilter.java
+++ b/micrometer-core/src/main/java/io/micronaut/configuration/metrics/binder/web/ClientMetricsFilter.java
@@ -71,7 +71,7 @@ final class ClientMetricsFilter {
 
     @ResponseFilter
     void doException(HttpRequest<?> request, Throwable throwable) {
-        createHelper(request).error(throwable);
+        createHelper(request).error(null, throwable);
     }
 
     private WebMetricsHelper createHelper(HttpRequest<?> request) {

--- a/micrometer-core/src/main/java/io/micronaut/configuration/metrics/binder/web/WebMetricsHelper.java
+++ b/micrometer-core/src/main/java/io/micronaut/configuration/metrics/binder/web/WebMetricsHelper.java
@@ -258,7 +258,7 @@ final class WebMetricsHelper {
                 // Should this be configurable?
                 success(httpResponse);
             } else {
-                error(throwable);
+                error(httpResponse, throwable);
             }
         } else {
             success(httpResponse);
@@ -279,14 +279,14 @@ final class WebMetricsHelper {
     /**
      * Registers the error timer for a web request when an exception occurs.
      *
-     * @param throwable exception that occurred
+     * @param httpResponse existing response object.
+     * @param throwable    exception that occurred
      */
-    public void error(Throwable throwable) {
-        HttpResponse<?> response = null;
-        if (throwable instanceof HttpResponseProvider httpResponseProvider) {
-            response = httpResponseProvider.getResponse();
+    public void error(HttpResponse<?> httpResponse, Throwable throwable) {
+        if (httpResponse == null && throwable instanceof HttpResponseProvider httpResponseProvider) {
+            httpResponse = httpResponseProvider.getResponse();
         }
-        List<Tag> tags = getTags(response, httpMethod, requestPath, throwable, serviceID, reportClientErrorURIs);
+        List<Tag> tags = getTags(httpResponse, httpMethod, requestPath, throwable, serviceID, reportClientErrorURIs);
         meterRegistry.timer(metricName, tags)
             .record(System.nanoTime() - start, NANOSECONDS);
     }

--- a/micrometer-core/src/test/java/io/micronaut/configuration/metrics/WebMetricsExceptionCodeTest.java
+++ b/micrometer-core/src/test/java/io/micronaut/configuration/metrics/WebMetricsExceptionCodeTest.java
@@ -15,7 +15,6 @@ import io.micronaut.http.client.BlockingHttpClient;
 import io.micronaut.http.client.HttpClient;
 import io.micronaut.http.client.annotation.Client;
 import io.micronaut.http.client.exceptions.HttpClientResponseException;
-import io.micronaut.http.exceptions.HttpStatusException;
 import io.micronaut.http.server.exceptions.ExceptionHandler;
 import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
 import jakarta.inject.Singleton;
@@ -50,9 +49,9 @@ class WebMetricsExceptionCodeTest {
         }
     }
 
-    static class GatewayTimeoutException extends HttpStatusException {
+    static class GatewayTimeoutException extends RuntimeException {
         public GatewayTimeoutException(String message) {
-            super(HttpStatus.GATEWAY_TIMEOUT, message);
+            super(message);
         }
     }
 

--- a/micrometer-core/src/test/java/io/micronaut/configuration/metrics/WebMetricsExceptionCodeTest.java
+++ b/micrometer-core/src/test/java/io/micronaut/configuration/metrics/WebMetricsExceptionCodeTest.java
@@ -34,9 +34,9 @@ class WebMetricsExceptionCodeTest {
         BlockingHttpClient client = httpClient.toBlocking();
         HttpClientResponseException e = Assertions.assertThrows(HttpClientResponseException.class, () ->  client.exchange( "/metrics/test"));
         Assertions.assertEquals(e.code(), HttpStatus.GATEWAY_TIMEOUT.getCode());
-        Assertions.assertEquals(e.getMessage(), "Client '/': Gateway Timeout");
+        Assertions.assertEquals("Client '/': Gateway Timeout", e.getMessage());
         long count = meterRegistry.timer("http.server.requests", List.of(Tag.of("method", "GET"), Tag.of("uri", "/metrics/test"), Tag.of("status", "504"), Tag.of("exception", "GatewayTimeoutException"))).count();
-        Assertions.assertEquals(count, 1);
+        Assertions.assertEquals(1, count);
     }
 
     @Controller("/metrics")

--- a/micrometer-core/src/test/java/io/micronaut/configuration/metrics/WebMetricsExceptionCodeTest.java
+++ b/micrometer-core/src/test/java/io/micronaut/configuration/metrics/WebMetricsExceptionCodeTest.java
@@ -1,0 +1,71 @@
+package io.micronaut.configuration.metrics;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
+import io.micronaut.context.annotation.Property;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.core.util.StringUtils;
+import io.micronaut.http.HttpRequest;
+import io.micronaut.http.HttpResponse;
+import io.micronaut.http.HttpStatus;
+import io.micronaut.http.annotation.Controller;
+import io.micronaut.http.annotation.Get;
+import io.micronaut.http.annotation.Produces;
+import io.micronaut.http.client.BlockingHttpClient;
+import io.micronaut.http.client.HttpClient;
+import io.micronaut.http.client.annotation.Client;
+import io.micronaut.http.client.exceptions.HttpClientResponseException;
+import io.micronaut.http.exceptions.HttpStatusException;
+import io.micronaut.http.server.exceptions.ExceptionHandler;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import jakarta.inject.Singleton;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+
+@MicronautTest
+@Property(name = "spec.name", value = "WebMetricsStatusCodeTest")
+@Property(name = "micronaut.metrics.binders.web.enabled", value = StringUtils.TRUE)
+class WebMetricsExceptionCodeTest {
+
+    @Test
+    void testWebMetricsCustomStatusCode(@Client("/") HttpClient httpClient, MeterRegistry meterRegistry) {
+        BlockingHttpClient client = httpClient.toBlocking();
+        HttpClientResponseException e = Assertions.assertThrows(HttpClientResponseException.class, () ->  client.exchange( "/metrics/test"));
+        Assertions.assertEquals(e.code(), HttpStatus.GATEWAY_TIMEOUT.getCode());
+        Assertions.assertEquals(e.getMessage(), "Client '/': Gateway Timeout");
+        long count = meterRegistry.timer("http.server.requests", List.of(Tag.of("method", "GET"), Tag.of("uri", "/metrics/test"), Tag.of("status", "504"), Tag.of("exception", "GatewayTimeoutException"))).count();
+        Assertions.assertEquals(count, 1);
+    }
+
+    @Controller("/metrics")
+    @Requires(property = "spec.name", value = "WebMetricsStatusCodeTest")
+    static class WebMetricsCustomStatusCodeController {
+
+        @Get("/test")
+        String test() {
+            throw new GatewayTimeoutException("GATEWAY TIMEOUT");
+        }
+    }
+
+    static class GatewayTimeoutException extends HttpStatusException {
+        public GatewayTimeoutException(String message) {
+            super(HttpStatus.GATEWAY_TIMEOUT, message);
+        }
+    }
+
+    @Produces
+    @Singleton
+    @Requires(property = "spec.name", value = "WebMetricsStatusCodeTest")
+    static class GatewayTimeoutExceptionHandler implements ExceptionHandler<GatewayTimeoutException, HttpResponse<?>> {
+
+        @Override
+        public HttpResponse<?> handle(HttpRequest request, GatewayTimeoutException exception) {
+            return HttpResponse.status(HttpStatus.GATEWAY_TIMEOUT)
+                .body(exception.getMessage());
+        }
+    }
+
+}


### PR DESCRIPTION
It considers first if http response exists otherwise it tries to extract it from the exception. Fixes #925. 