### PR TITLE
Fix stack overflow when Netty queues metrics are enabled for UNIX listener

### DIFF
--- a/micrometer-core/src/main/java/io/micronaut/configuration/metrics/binder/netty/InstrumentedEpollEventLoopGroupFactory.java
+++ b/micrometer-core/src/main/java/io/micronaut/configuration/metrics/binder/netty/InstrumentedEpollEventLoopGroupFactory.java
@@ -19,20 +19,14 @@ import io.micronaut.configuration.metrics.annotation.RequiresMetrics;
 import io.micronaut.context.annotation.Replaces;
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.core.annotation.Internal;
-import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.annotation.Nullable;
 import io.micronaut.http.netty.channel.EpollAvailabilityCondition;
 import io.micronaut.http.netty.channel.EpollEventLoopGroupFactory;
-import io.micronaut.http.netty.channel.EventLoopGroupConfiguration;
 import io.micronaut.http.netty.channel.EventLoopGroupFactory;
 import io.netty.channel.DefaultSelectStrategyFactory;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.epoll.Epoll;
 import io.netty.channel.epoll.EpollEventLoopGroup;
-import io.netty.channel.epoll.EpollServerSocketChannel;
-import io.netty.channel.epoll.EpollSocketChannel;
-import io.netty.channel.socket.ServerSocketChannel;
-import io.netty.channel.socket.SocketChannel;
 import io.netty.util.concurrent.DefaultEventExecutorChooserFactory;
 import io.netty.util.concurrent.RejectedExecutionHandlers;
 import io.netty.util.concurrent.ThreadPerTaskExecutor;
@@ -58,7 +52,7 @@ import static io.micronaut.core.util.StringUtils.FALSE;
 @Requires(classes = Epoll.class, condition = EpollAvailabilityCondition.class)
 @RequiresMetrics
 @Requires(property = MICRONAUT_METRICS_BINDERS + ".netty.queues.enabled", defaultValue = FALSE, notEquals = FALSE)
-final class InstrumentedEpollEventLoopGroupFactory implements EventLoopGroupFactory {
+final class InstrumentedEpollEventLoopGroupFactory extends EpollEventLoopGroupFactory {
 
     private final InstrumentedEventLoopTaskQueueFactory instrumentedEventLoopTaskQueueFactory;
 
@@ -98,21 +92,5 @@ final class InstrumentedEpollEventLoopGroupFactory implements EventLoopGroupFact
                 DefaultSelectStrategyFactory.INSTANCE,
                 RejectedExecutionHandlers.reject(),
                 instrumentedEventLoopTaskQueueFactory);
-    }
-
-    @Override
-    public Class<? extends ServerSocketChannel> serverSocketChannelClass() {
-        return EpollServerSocketChannel.class;
-    }
-
-    @NonNull
-    @Override
-    public Class<? extends SocketChannel> clientSocketChannelClass(@Nullable EventLoopGroupConfiguration configuration) {
-        return EpollSocketChannel.class;
-    }
-
-    @Override
-    public boolean isNative() {
-        return true;
     }
 }

--- a/micrometer-core/src/main/java/io/micronaut/configuration/metrics/binder/netty/InstrumentedKQueueEventLoopGroupFactory.java
+++ b/micrometer-core/src/main/java/io/micronaut/configuration/metrics/binder/netty/InstrumentedKQueueEventLoopGroupFactory.java
@@ -19,9 +19,7 @@ import io.micronaut.configuration.metrics.annotation.RequiresMetrics;
 import io.micronaut.context.annotation.Replaces;
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.core.annotation.Internal;
-import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.annotation.Nullable;
-import io.micronaut.http.netty.channel.EventLoopGroupConfiguration;
 import io.micronaut.http.netty.channel.EventLoopGroupFactory;
 import io.micronaut.http.netty.channel.KQueueAvailabilityCondition;
 import io.micronaut.http.netty.channel.KQueueEventLoopGroupFactory;
@@ -29,10 +27,6 @@ import io.netty.channel.DefaultSelectStrategyFactory;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.kqueue.KQueue;
 import io.netty.channel.kqueue.KQueueEventLoopGroup;
-import io.netty.channel.kqueue.KQueueServerSocketChannel;
-import io.netty.channel.kqueue.KQueueSocketChannel;
-import io.netty.channel.socket.ServerSocketChannel;
-import io.netty.channel.socket.SocketChannel;
 import io.netty.util.concurrent.DefaultEventExecutorChooserFactory;
 import io.netty.util.concurrent.RejectedExecutionHandlers;
 import io.netty.util.concurrent.ThreadPerTaskExecutor;
@@ -58,7 +52,7 @@ import static io.micronaut.core.util.StringUtils.FALSE;
 @Requires(classes = KQueue.class, condition = KQueueAvailabilityCondition.class)
 @RequiresMetrics
 @Requires(property = MICRONAUT_METRICS_BINDERS + ".netty.queues.enabled", defaultValue = FALSE, notEquals = FALSE)
-final class InstrumentedKQueueEventLoopGroupFactory implements EventLoopGroupFactory {
+final class InstrumentedKQueueEventLoopGroupFactory extends KQueueEventLoopGroupFactory {
 
     private final InstrumentedEventLoopTaskQueueFactory instrumentedEventLoopTaskQueueFactory;
 
@@ -99,22 +93,6 @@ final class InstrumentedKQueueEventLoopGroupFactory implements EventLoopGroupFac
                 DefaultSelectStrategyFactory.INSTANCE,
                 RejectedExecutionHandlers.reject(),
                 instrumentedEventLoopTaskQueueFactory), ioRatio);
-    }
-
-    @Override
-    public boolean isNative() {
-        return true;
-    }
-
-    @Override
-    public Class<? extends ServerSocketChannel> serverSocketChannelClass() {
-        return KQueueServerSocketChannel.class;
-    }
-
-    @NonNull
-    @Override
-    public Class<? extends SocketChannel> clientSocketChannelClass(@Nullable EventLoopGroupConfiguration configuration) {
-        return KQueueSocketChannel.class;
     }
 
     private static KQueueEventLoopGroup withIoRatio(KQueueEventLoopGroup group, @Nullable Integer ioRatio) {

--- a/micrometer-core/src/main/java/io/micronaut/configuration/metrics/binder/netty/InstrumentedNioEventLoopGroupFactory.java
+++ b/micrometer-core/src/main/java/io/micronaut/configuration/metrics/binder/netty/InstrumentedNioEventLoopGroupFactory.java
@@ -19,17 +19,11 @@ import io.micronaut.configuration.metrics.annotation.RequiresMetrics;
 import io.micronaut.context.annotation.Replaces;
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.core.annotation.Internal;
-import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.annotation.Nullable;
-import io.micronaut.http.netty.channel.EventLoopGroupConfiguration;
 import io.micronaut.http.netty.channel.NioEventLoopGroupFactory;
 import io.netty.channel.DefaultSelectStrategyFactory;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.nio.NioEventLoopGroup;
-import io.netty.channel.socket.ServerSocketChannel;
-import io.netty.channel.socket.SocketChannel;
-import io.netty.channel.socket.nio.NioServerSocketChannel;
-import io.netty.channel.socket.nio.NioSocketChannel;
 import io.netty.util.concurrent.DefaultEventExecutorChooserFactory;
 import io.netty.util.concurrent.RejectedExecutionHandlers;
 import io.netty.util.concurrent.ThreadPerTaskExecutor;
@@ -96,17 +90,6 @@ final class InstrumentedNioEventLoopGroupFactory extends NioEventLoopGroupFactor
                 DefaultSelectStrategyFactory.INSTANCE,
                 RejectedExecutionHandlers.reject(),
                 instrumentedEventLoopTaskQueueFactory), ioRatio);
-    }
-
-    @Override
-    public Class<? extends ServerSocketChannel> serverSocketChannelClass() {
-        return NioServerSocketChannel.class;
-    }
-
-    @NonNull
-    @Override
-    public Class<? extends SocketChannel> clientSocketChannelClass(@Nullable EventLoopGroupConfiguration configuration) {
-        return NioSocketChannel.class;
     }
 
     private static NioEventLoopGroup withIoRatio(NioEventLoopGroup group,


### PR DESCRIPTION
### Bug Description 

Getting `StackOverflowError` on application startup trying to create domain socket server channel instance:

```
java.lang.StackOverflowError: null
        at io.micronaut.http.netty.channel.EventLoopGroupFactory.domainServerSocketChannelInstance(EventLoopGroupFactory.java:212)
        at io.micronaut.http.netty.channel.EventLoopGroupFactory.channelInstance(EventLoopGroupFactory.java:227)
```

### Steps To Reproduce

Create a Micronaut application with UNIX listener and Netty queues metrics enabled:

```
micronaut:
  server:
    netty:
      listeners:
        unixListener:
          family: UNIX
          path: file.sock
  metrics:
    enabled: true
    binders:
      netty:
        queues:
          enabled: true
```

### Proposed Fix

Current implementations of `InstrumentedKQueueEventLoopGroupFactory` and `InstrumentedEpollEventLoopGroupFactory` don't handle any channel types other than `SERVER_SOCKET` and `CLIENT_SOCKET`.
We should be able to reuse the logic from `KQueueEventLoopGroupFactory` and `EpollEventLoopGroupFactory` to support other possible channel types.