### PR TITLE
Fix pushgateway deps

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,7 +11,7 @@ managed-metrics-core = '4.2.30'
 managed-micrometer = '1.13.6'
 managed-micrometer-tracing = '1.4.1'
 managed-new-relic-registry = '0.10.0'
-prometheus-pushgateway = '1.3.6'
+managed-prometheus-metrics-exporter-pushgateway = '1.3.6'
 managed-datasource-micrometer = '1.0.6'
 reflections = '0.10.2'
 
@@ -52,11 +52,11 @@ boms-micrometer = { module = 'io.micrometer:micrometer-bom', version.ref = 'mana
 grpc-api = { module = 'io.grpc:grpc-api' }
 hdr-histogram = { module = 'org.hdrhistogram:HdrHistogram', version.ref = 'hdr-histogram' }
 
-prometheus-metrics-exporter-pushgateway = { module = 'io.prometheus:prometheus-metrics-exporter-pushgateway', version.ref = 'prometheus-pushgateway' }
-prometheus-metrics-config = { module = 'io.prometheus:prometheus-metrics-config', version.ref = 'prometheus-pushgateway' }
-prometheus-metrics-core = { module = 'io.prometheus:prometheus-metrics-core', version.ref = 'prometheus-pushgateway' }
-prometheus-metrics-exposition-formats = { module = 'io.prometheus:prometheus-metrics-exposition-formats', version.ref = 'prometheus-pushgateway' }
-prometheus-metrics-tracer-common = { module = 'io.prometheus:prometheus-metrics-tracer-common', version.ref = 'prometheus-pushgateway' }
+managed-prometheus-metrics-exporter-pushgateway = { module = 'io.prometheus:prometheus-metrics-exporter-pushgateway', version.ref = 'managed-prometheus-metrics-exporter-pushgateway' }
+prometheus-metrics-config = { module = 'io.prometheus:prometheus-metrics-config', version.ref = 'managed-prometheus-metrics-exporter-pushgateway' }
+prometheus-metrics-core = { module = 'io.prometheus:prometheus-metrics-core', version.ref = 'managed-prometheus-metrics-exporter-pushgateway' }
+prometheus-metrics-exposition-formats = { module = 'io.prometheus:prometheus-metrics-exposition-formats', version.ref = 'managed-prometheus-metrics-exporter-pushgateway' }
+prometheus-metrics-tracer-common = { module = 'io.prometheus:prometheus-metrics-tracer-common', version.ref = 'managed-prometheus-metrics-exporter-pushgateway' }
 
 managed-metrics-core = { module = 'io.dropwizard.metrics:metrics-core', version.ref = 'managed-metrics-core' }
 managed-micrometer-registry-new-relic-telemetry = { module = 'com.newrelic.telemetry:micrometer-registry-new-relic', version.ref = 'managed-new-relic-registry' }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,7 +11,7 @@ managed-metrics-core = '4.2.30'
 managed-micrometer = '1.13.6'
 managed-micrometer-tracing = '1.4.1'
 managed-new-relic-registry = '0.10.0'
-managed-prometheus-metrics-exporter-pushgateway = '1.3.6'
+managed-prometheus-pushgateway = '1.3.6'
 managed-datasource-micrometer = '1.0.6'
 reflections = '0.10.2'
 
@@ -52,7 +52,11 @@ boms-micrometer = { module = 'io.micrometer:micrometer-bom', version.ref = 'mana
 grpc-api = { module = 'io.grpc:grpc-api' }
 hdr-histogram = { module = 'org.hdrhistogram:HdrHistogram', version.ref = 'hdr-histogram' }
 
-managed-prometheus-metrics-exporter-pushgateway = { module = 'io.prometheus:prometheus-metrics-exporter-pushgateway', version.ref = 'managed-prometheus-metrics-exporter-pushgateway' }
+managed-prometheus-metrics-exporter-pushgateway = { module = 'io.prometheus:prometheus-metrics-exporter-pushgateway', version.ref = 'managed-prometheus-pushgateway' }
+managed-prometheus-metrics-config = { module = 'io.prometheus:prometheus-metrics-config', version.ref = 'managed-prometheus-pushgateway' }
+managed-prometheus-metrics-core = { module = 'io.prometheus:prometheus-metrics-core', version.ref = 'managed-prometheus-pushgateway' }
+managed-prometheus-metrics-exposition-formats = { module = 'io.prometheus:prometheus-metrics-exposition-formats', version.ref = 'managed-prometheus-pushgateway' }
+managed-prometheus-metrics-tracer-common = { module = 'io.prometheus:prometheus-metrics-tracer-common', version.ref = 'managed-prometheus-pushgateway' }
 
 managed-metrics-core = { module = 'io.dropwizard.metrics:metrics-core', version.ref = 'managed-metrics-core' }
 managed-micrometer-registry-new-relic-telemetry = { module = 'com.newrelic.telemetry:micrometer-registry-new-relic', version.ref = 'managed-new-relic-registry' }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,7 +11,7 @@ managed-metrics-core = '4.2.30'
 managed-micrometer = '1.13.6'
 managed-micrometer-tracing = '1.4.1'
 managed-new-relic-registry = '0.10.0'
-managed-prometheus-pushgateway = '1.3.6'
+prometheus-pushgateway = '1.3.6'
 managed-datasource-micrometer = '1.0.6'
 reflections = '0.10.2'
 
@@ -52,11 +52,11 @@ boms-micrometer = { module = 'io.micrometer:micrometer-bom', version.ref = 'mana
 grpc-api = { module = 'io.grpc:grpc-api' }
 hdr-histogram = { module = 'org.hdrhistogram:HdrHistogram', version.ref = 'hdr-histogram' }
 
-managed-prometheus-metrics-exporter-pushgateway = { module = 'io.prometheus:prometheus-metrics-exporter-pushgateway', version.ref = 'managed-prometheus-pushgateway' }
-managed-prometheus-metrics-config = { module = 'io.prometheus:prometheus-metrics-config', version.ref = 'managed-prometheus-pushgateway' }
-managed-prometheus-metrics-core = { module = 'io.prometheus:prometheus-metrics-core', version.ref = 'managed-prometheus-pushgateway' }
-managed-prometheus-metrics-exposition-formats = { module = 'io.prometheus:prometheus-metrics-exposition-formats', version.ref = 'managed-prometheus-pushgateway' }
-managed-prometheus-metrics-tracer-common = { module = 'io.prometheus:prometheus-metrics-tracer-common', version.ref = 'managed-prometheus-pushgateway' }
+prometheus-metrics-exporter-pushgateway = { module = 'io.prometheus:prometheus-metrics-exporter-pushgateway', version.ref = 'prometheus-pushgateway' }
+prometheus-metrics-config = { module = 'io.prometheus:prometheus-metrics-config', version.ref = 'prometheus-pushgateway' }
+prometheus-metrics-core = { module = 'io.prometheus:prometheus-metrics-core', version.ref = 'prometheus-pushgateway' }
+prometheus-metrics-exposition-formats = { module = 'io.prometheus:prometheus-metrics-exposition-formats', version.ref = 'prometheus-pushgateway' }
+prometheus-metrics-tracer-common = { module = 'io.prometheus:prometheus-metrics-tracer-common', version.ref = 'prometheus-pushgateway' }
 
 managed-metrics-core = { module = 'io.dropwizard.metrics:metrics-core', version.ref = 'managed-metrics-core' }
 managed-micrometer-registry-new-relic-telemetry = { module = 'com.newrelic.telemetry:micrometer-registry-new-relic', version.ref = 'managed-new-relic-registry' }

--- a/micrometer-registry-prometheus-pushgateway/build.gradle
+++ b/micrometer-registry-prometheus-pushgateway/build.gradle
@@ -5,7 +5,7 @@ plugins {
 dependencies {
     api libs.micrometer.registry.prometheus
     api projects.micronautMicrometerRegistryPrometheus
-    implementation libs.prometheus.metrics.exporter.pushgateway
+    implementation libs.managed.prometheus.metrics.exporter.pushgateway
     implementation libs.prometheus.metrics.config
     implementation libs.prometheus.metrics.core
     implementation libs.prometheus.metrics.exposition.formats

--- a/micrometer-registry-prometheus-pushgateway/build.gradle
+++ b/micrometer-registry-prometheus-pushgateway/build.gradle
@@ -5,11 +5,11 @@ plugins {
 dependencies {
     api libs.micrometer.registry.prometheus
     api projects.micronautMicrometerRegistryPrometheus
-    implementation libs.managed.prometheus.metrics.exporter.pushgateway
-    implementation libs.managed.prometheus.metrics.config
-    implementation libs.managed.prometheus.metrics.core
-    implementation libs.managed.prometheus.metrics.exposition.formats
-    implementation libs.managed.prometheus.metrics.tracer.common
+    implementation libs.prometheus.metrics.exporter.pushgateway
+    implementation libs.prometheus.metrics.config
+    implementation libs.prometheus.metrics.core
+    implementation libs.prometheus.metrics.exposition.formats
+    implementation libs.prometheus.metrics.tracer.common
     testImplementation(mnSerde.micronaut.serde.jackson)
 }
 

--- a/micrometer-registry-prometheus-pushgateway/build.gradle
+++ b/micrometer-registry-prometheus-pushgateway/build.gradle
@@ -5,11 +5,11 @@ plugins {
 dependencies {
     api libs.micrometer.registry.prometheus
     api projects.micronautMicrometerRegistryPrometheus
-    implementation libs.managed.prometheus.metrics.exporter.pushgateway
-    implementation libs.prometheus.metrics.config
-    implementation libs.prometheus.metrics.core
-    implementation libs.prometheus.metrics.exposition.formats
-    implementation libs.prometheus.metrics.tracer.common
+    api libs.managed.prometheus.metrics.exporter.pushgateway
+    api libs.prometheus.metrics.config
+    api libs.prometheus.metrics.core
+    api libs.prometheus.metrics.exposition.formats
+    api libs.prometheus.metrics.tracer.common
     testImplementation(mnSerde.micronaut.serde.jackson)
 }
 

--- a/micrometer-registry-prometheus-pushgateway/build.gradle
+++ b/micrometer-registry-prometheus-pushgateway/build.gradle
@@ -5,7 +5,11 @@ plugins {
 dependencies {
     api libs.micrometer.registry.prometheus
     api projects.micronautMicrometerRegistryPrometheus
-    api libs.managed.prometheus.metrics.exporter.pushgateway
+    implementation libs.managed.prometheus.metrics.exporter.pushgateway
+    implementation libs.managed.prometheus.metrics.config
+    implementation libs.managed.prometheus.metrics.core
+    implementation libs.managed.prometheus.metrics.exposition.formats
+    implementation libs.managed.prometheus.metrics.tracer.common
     testImplementation(mnSerde.micronaut.serde.jackson)
 }
 


### PR DESCRIPTION
Fixes #992

Changed from `implementation` to `api` since gradle has issues with resolving dependencies. I guess it has to do with `micronaut-micrometer-registry-prometheus-pushgateway-5.10.3-SNAPSHOT.module` file.
