### PR TITLE
Update metricsAndReportersAzureMonitor.adoc

### DIFF
--- a/src/main/docs/guide/metricsAndReporters/metricsAndReportersAzureMonitor.adoc
+++ b/src/main/docs/guide/metricsAndReporters/metricsAndReportersAzureMonitor.adoc
@@ -7,7 +7,7 @@ You can configure this reporter using `micronaut.metrics.export.azuremonitor`. T
 |=======
 |*Name* |*Description*
 |enabled |Whether to enable the reporter, for example per-environment or for local development. Default: `true`
-|instrumentationKey | Azure Monitor instrumentation key. Required.
+|connectionString | Azure Monitor connection string. Required.
 |step |How frequently to report metrics. Default: `PT1M` (1 min). See `java.time.Duration#parse(CharSequence)`
 |=======
 
@@ -20,6 +20,6 @@ micronaut:
     export:
       azuremonitor:
         enabled: true
-        instrumentationKey: ${AZUREMONITOR_INSTRUMENTATION_KEY}
+        connectionString: ${AZUREMONITOR_CONNECTION_STRING}
         step: PT1M
 ----


### PR DESCRIPTION
As stated in the following URL, the instrumentation key is deprecated in Azure Monitor, yet it is still described as a required property in the Azure Monitor reporter document.
Connection string support for [AzureMonitorConfig.java](https://github.com/micrometer-metrics/micrometer/blob/main/implementations/micrometer-registry-azure-monitor/src/main/java/io/micrometer/azuremonitor/AzureMonitorConfig.java) is already available, so I have created this PR to update the document accordingly.

> On March 31, 2025, support for instrumentation key ingestion will end. Instrumentation key ingestion will continue to work, but we'll no longer provide updates or support for the feature. [Transition to connection strings](https://learn.microsoft.com/en-us/azure/azure-monitor/app/migrate-from-instrumentation-keys-to-connection-strings) to take advantage of [new capabilities](https://learn.microsoft.com/en-us/azure/azure-monitor/app/migrate-from-instrumentation-keys-to-connection-strings#new-capabilities).
> Connection strings in Application Insights: [https://learn.microsoft.com/en-us/azure/azure-monitor/app/connection-strings](https://learn.microsoft.com/en-us/azure/azure-monitor/app/connection-strings)
