### PR TITLE
fix(deps): combine Renovate batch for issue #1142

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,11 +3,11 @@ micronaut-platform = "4.10.11"
 micronaut = "5.0.0-M21"
 micronaut-gradle-plugin = "4.6.2"
 
-managed-metrics-core = '4.2.37'
-managed-micrometer = '1.16.1'
-managed-micrometer-tracing = '1.6.1'
+managed-metrics-core = '4.2.38'
+managed-micrometer = '1.16.5'
+managed-micrometer-tracing = '1.6.5'
 managed-new-relic-registry = '0.10.0'
-managed-prometheus-metrics-exporter-pushgateway = '1.4.3'
+managed-prometheus-metrics-exporter-pushgateway = '1.5.1'
 managed-datasource-micrometer = '2.2.1'
 reflections = '0.10.2'
 


### PR DESCRIPTION
## Summary
- combine Renovate PRs #1117, #1110, and #1107 into one dependency-upgrade branch
- upgrade metrics-core to 4.2.38, micrometer/micrometer-tracing to 1.16.5/1.6.5, and prometheus pushgateway exporter to 1.5.1
- keep the change isolated to the shared version catalog

## Verification
- attempted `./gradlew check -q -x japiCmp -x checkVersionCatalogCompatibility`, but this workspace repeatedly received external `Gradle build daemon has been stopped: stop command received` interruptions
- attempted `./gradlew --no-daemon -q :micronaut-micrometer-bom:checkBom :micronaut-micrometer-core:compileJava :micronaut-micrometer-observation:compileJava :micronaut-micrometer-registry-prometheus-pushgateway:compileJava` with the same external daemon-stop interruption
- confirmed the visible `ModifierOrder` checkstyle error in `MetricOptionsUtil` is already present on `origin/6.0.x`, so it is not introduced by this branch

Resolves #1142