### PR TITLE
Stream Prometheus scrape responses

### DIFF
--- a/micrometer-registry-prometheus/src/main/java/io/micronaut/configuration/metrics/micrometer/prometheus/management/PrometheusEndpoint.java
+++ b/micrometer-registry-prometheus/src/main/java/io/micronaut/configuration/metrics/micrometer/prometheus/management/PrometheusEndpoint.java
@@ -72,7 +72,7 @@ public class PrometheusEndpoint {
      * @return the data
      * @deprecated Use the streamed endpoint response instead.
      */
-    @Deprecated
+    @Deprecated(since = "6.0")
     public String scrape() {
         return prometheusMeterRegistry.scrape();
     }
@@ -93,16 +93,21 @@ public class PrometheusEndpoint {
         private final PipedOutputStream outputStream;
         private Future<?> writeFuture;
 
-        ProducerAwareInputStream(InputStream inputStream, PipedOutputStream outputStream) {
+        ProducerAwareInputStream(PipedInputStream inputStream) throws IOException {
             super(inputStream);
-            this.outputStream = outputStream;
+            this.outputStream = new PipedOutputStream(inputStream);
         }
 
         static ProducerAwareInputStream create() {
+            PipedInputStream inputStream = new PipedInputStream(PIPE_BUFFER_SIZE);
             try {
-                PipedInputStream inputStream = new PipedInputStream(PIPE_BUFFER_SIZE);
-                return new ProducerAwareInputStream(inputStream, new PipedOutputStream(inputStream));
+                return new ProducerAwareInputStream(inputStream);
             } catch (IOException e) {
+                try {
+                    inputStream.close();
+                } catch (IOException closeException) {
+                    e.addSuppressed(closeException);
+                }
                 throw new IllegalStateException("Failed to create Prometheus scrape stream", e);
             }
         }

--- a/micrometer-registry-prometheus/src/main/java/io/micronaut/configuration/metrics/micrometer/prometheus/management/PrometheusEndpoint.java
+++ b/micrometer-registry-prometheus/src/main/java/io/micronaut/configuration/metrics/micrometer/prometheus/management/PrometheusEndpoint.java
@@ -84,29 +84,48 @@ public class PrometheusEndpoint {
      */
     @Read(produces = "text/plain; version=0.0.4")
     public InputStream scrapeStream() {
-        PipedInputStream inputStream = new PipedInputStream(PIPE_BUFFER_SIZE);
-        PipedOutputStream outputStream;
-        try {
-            outputStream = new PipedOutputStream(inputStream);
-        } catch (IOException e) {
-            throw new IllegalStateException("Failed to create Prometheus scrape stream", e);
+        ProducerAwareInputStream inputStream = ProducerAwareInputStream.create();
+        inputStream.start(scrapeExecutor, prometheusMeterRegistry);
+        return inputStream;
+    }
+
+    private static final class ProducerAwareInputStream extends FilterInputStream {
+        private final PipedOutputStream outputStream;
+        private Future<?> writeFuture;
+
+        ProducerAwareInputStream(InputStream inputStream, PipedOutputStream outputStream) {
+            super(inputStream);
+            this.outputStream = outputStream;
         }
-        Future<?> writeFuture = scrapeExecutor.submit(() -> {
+
+        static ProducerAwareInputStream create() {
+            try {
+                PipedInputStream inputStream = new PipedInputStream(PIPE_BUFFER_SIZE);
+                return new ProducerAwareInputStream(inputStream, new PipedOutputStream(inputStream));
+            } catch (IOException e) {
+                throw new IllegalStateException("Failed to create Prometheus scrape stream", e);
+            }
+        }
+
+        void start(ExecutorService scrapeExecutor, PrometheusMeterRegistry prometheusMeterRegistry) {
+            try {
+                writeFuture = scrapeExecutor.submit(() -> writeScrape(prometheusMeterRegistry));
+            } catch (RuntimeException e) {
+                try {
+                    close();
+                } catch (IOException closeException) {
+                    e.addSuppressed(closeException);
+                }
+                throw e;
+            }
+        }
+
+        private void writeScrape(PrometheusMeterRegistry prometheusMeterRegistry) {
             try (PipedOutputStream stream = outputStream) {
                 prometheusMeterRegistry.scrape(stream);
             } catch (IOException e) {
                 throw new UncheckedIOException(e);
             }
-        });
-        return new ProducerAwareInputStream(inputStream, writeFuture);
-    }
-
-    private static final class ProducerAwareInputStream extends FilterInputStream {
-        private final Future<?> writeFuture;
-
-        private ProducerAwareInputStream(InputStream inputStream, Future<?> writeFuture) {
-            super(inputStream);
-            this.writeFuture = writeFuture;
         }
 
         @Override
@@ -125,10 +144,26 @@ public class PrometheusEndpoint {
 
         @Override
         public void close() throws IOException {
+            IOException closeException = null;
             try {
                 super.close();
-            } finally {
+            } catch (IOException e) {
+                closeException = e;
+            }
+            try {
+                outputStream.close();
+            } catch (IOException e) {
+                if (closeException == null) {
+                    closeException = e;
+                } else {
+                    closeException.addSuppressed(e);
+                }
+            }
+            if (writeFuture != null) {
                 writeFuture.cancel(true);
+            }
+            if (closeException != null) {
+                throw closeException;
             }
         }
 

--- a/micrometer-registry-prometheus/src/main/java/io/micronaut/configuration/metrics/micrometer/prometheus/management/PrometheusEndpoint.java
+++ b/micrometer-registry-prometheus/src/main/java/io/micronaut/configuration/metrics/micrometer/prometheus/management/PrometheusEndpoint.java
@@ -103,11 +103,6 @@ public class PrometheusEndpoint {
             try {
                 return new ProducerAwareInputStream(inputStream);
             } catch (IOException e) {
-                try {
-                    inputStream.close();
-                } catch (IOException closeException) {
-                    e.addSuppressed(closeException);
-                }
                 throw new IllegalStateException("Failed to create Prometheus scrape stream", e);
             }
         }

--- a/micrometer-registry-prometheus/src/main/java/io/micronaut/configuration/metrics/micrometer/prometheus/management/PrometheusEndpoint.java
+++ b/micrometer-registry-prometheus/src/main/java/io/micronaut/configuration/metrics/micrometer/prometheus/management/PrometheusEndpoint.java
@@ -29,10 +29,9 @@ import java.io.PipedInputStream;
 import java.io.PipedOutputStream;
 import java.io.UncheckedIOException;
 import java.util.concurrent.CancellationException;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionException;
-import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
 import java.util.concurrent.ForkJoinPool;
 
 /**
@@ -47,7 +46,7 @@ public class PrometheusEndpoint {
     private static final int PIPE_BUFFER_SIZE = 64 * 1024;
 
     private final PrometheusMeterRegistry prometheusMeterRegistry;
-    private final Executor scrapeExecutor;
+    private final ExecutorService scrapeExecutor;
 
     /**
      * @param prometheusMeterRegistry The meter registry
@@ -67,9 +66,15 @@ public class PrometheusEndpoint {
         this.scrapeExecutor = scrapeExecutor;
     }
 
-    private PrometheusEndpoint(PrometheusMeterRegistry prometheusMeterRegistry, Executor scrapeExecutor) {
-        this.prometheusMeterRegistry = prometheusMeterRegistry;
-        this.scrapeExecutor = scrapeExecutor;
+    /**
+     * Scrapes the data.
+     *
+     * @return the data
+     * @deprecated Use the streamed endpoint response instead.
+     */
+    @Deprecated
+    public String scrape() {
+        return prometheusMeterRegistry.scrape();
     }
 
     /**
@@ -78,7 +83,7 @@ public class PrometheusEndpoint {
      * @return the data
      */
     @Read(produces = "text/plain; version=0.0.4")
-    public InputStream scrape() {
+    public InputStream scrapeStream() {
         PipedInputStream inputStream = new PipedInputStream(PIPE_BUFFER_SIZE);
         PipedOutputStream outputStream;
         try {
@@ -86,20 +91,20 @@ public class PrometheusEndpoint {
         } catch (IOException e) {
             throw new IllegalStateException("Failed to create Prometheus scrape stream", e);
         }
-        CompletableFuture<Void> writeFuture = CompletableFuture.runAsync(() -> {
+        Future<?> writeFuture = scrapeExecutor.submit(() -> {
             try (PipedOutputStream stream = outputStream) {
                 prometheusMeterRegistry.scrape(stream);
             } catch (IOException e) {
                 throw new UncheckedIOException(e);
             }
-        }, scrapeExecutor);
+        });
         return new ProducerAwareInputStream(inputStream, writeFuture);
     }
 
     private static final class ProducerAwareInputStream extends FilterInputStream {
-        private final CompletableFuture<Void> writeFuture;
+        private final Future<?> writeFuture;
 
-        private ProducerAwareInputStream(InputStream inputStream, CompletableFuture<Void> writeFuture) {
+        private ProducerAwareInputStream(InputStream inputStream, Future<?> writeFuture) {
             super(inputStream);
             this.writeFuture = writeFuture;
         }
@@ -135,10 +140,13 @@ public class PrometheusEndpoint {
 
         private void awaitProducer() throws IOException {
             try {
-                writeFuture.join();
+                writeFuture.get();
             } catch (CancellationException ignored) {
                 // The consumer closed the stream early.
-            } catch (CompletionException e) {
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new IOException("Interrupted while streaming Prometheus scrape", e);
+            } catch (ExecutionException e) {
                 Throwable cause = e.getCause();
                 if (cause instanceof UncheckedIOException uncheckedIOException) {
                     throw uncheckedIOException.getCause();

--- a/micrometer-registry-prometheus/src/main/java/io/micronaut/configuration/metrics/micrometer/prometheus/management/PrometheusEndpoint.java
+++ b/micrometer-registry-prometheus/src/main/java/io/micronaut/configuration/metrics/micrometer/prometheus/management/PrometheusEndpoint.java
@@ -18,6 +18,22 @@ package io.micronaut.configuration.metrics.micrometer.prometheus.management;
 import io.micrometer.prometheusmetrics.PrometheusMeterRegistry;
 import io.micronaut.management.endpoint.annotation.Endpoint;
 import io.micronaut.management.endpoint.annotation.Read;
+import io.micronaut.scheduling.TaskExecutors;
+import jakarta.inject.Inject;
+import jakarta.inject.Named;
+
+import java.io.FilterInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.PipedInputStream;
+import java.io.PipedOutputStream;
+import java.io.UncheckedIOException;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ForkJoinPool;
 
 /**
  * Adds a management endpoint for Prometheus.
@@ -27,16 +43,33 @@ import io.micronaut.management.endpoint.annotation.Read;
  */
 @Endpoint(PrometheusEndpoint.ID)
 public class PrometheusEndpoint {
-
     public static final String ID = "prometheus";
+    private static final int PIPE_BUFFER_SIZE = 64 * 1024;
 
     private final PrometheusMeterRegistry prometheusMeterRegistry;
+    private final Executor scrapeExecutor;
 
     /**
      * @param prometheusMeterRegistry The meter registry
      */
     public PrometheusEndpoint(PrometheusMeterRegistry prometheusMeterRegistry) {
+        this(prometheusMeterRegistry, ForkJoinPool.commonPool());
+    }
+
+    /**
+     * @param prometheusMeterRegistry The meter registry
+     * @param scrapeExecutor The executor used to stream the scrape
+     */
+    @Inject
+    public PrometheusEndpoint(PrometheusMeterRegistry prometheusMeterRegistry,
+                              @Named(TaskExecutors.BLOCKING) ExecutorService scrapeExecutor) {
         this.prometheusMeterRegistry = prometheusMeterRegistry;
+        this.scrapeExecutor = scrapeExecutor;
+    }
+
+    private PrometheusEndpoint(PrometheusMeterRegistry prometheusMeterRegistry, Executor scrapeExecutor) {
+        this.prometheusMeterRegistry = prometheusMeterRegistry;
+        this.scrapeExecutor = scrapeExecutor;
     }
 
     /**
@@ -45,7 +78,73 @@ public class PrometheusEndpoint {
      * @return the data
      */
     @Read(produces = "text/plain; version=0.0.4")
-    public String scrape() {
-        return prometheusMeterRegistry.scrape();
+    public InputStream scrape() {
+        PipedInputStream inputStream = new PipedInputStream(PIPE_BUFFER_SIZE);
+        PipedOutputStream outputStream;
+        try {
+            outputStream = new PipedOutputStream(inputStream);
+        } catch (IOException e) {
+            throw new IllegalStateException("Failed to create Prometheus scrape stream", e);
+        }
+        CompletableFuture<Void> writeFuture = CompletableFuture.runAsync(() -> {
+            try (PipedOutputStream stream = outputStream) {
+                prometheusMeterRegistry.scrape(stream);
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+        }, scrapeExecutor);
+        return new ProducerAwareInputStream(inputStream, writeFuture);
+    }
+
+    private static final class ProducerAwareInputStream extends FilterInputStream {
+        private final CompletableFuture<Void> writeFuture;
+
+        private ProducerAwareInputStream(InputStream inputStream, CompletableFuture<Void> writeFuture) {
+            super(inputStream);
+            this.writeFuture = writeFuture;
+        }
+
+        @Override
+        public int read() throws IOException {
+            int read = super.read();
+            verifyProducer(read);
+            return read;
+        }
+
+        @Override
+        public int read(byte[] b, int off, int len) throws IOException {
+            int read = super.read(b, off, len);
+            verifyProducer(read);
+            return read;
+        }
+
+        @Override
+        public void close() throws IOException {
+            try {
+                super.close();
+            } finally {
+                writeFuture.cancel(true);
+            }
+        }
+
+        private void verifyProducer(int read) throws IOException {
+            if (read == -1) {
+                awaitProducer();
+            }
+        }
+
+        private void awaitProducer() throws IOException {
+            try {
+                writeFuture.join();
+            } catch (CancellationException ignored) {
+                // The consumer closed the stream early.
+            } catch (CompletionException e) {
+                Throwable cause = e.getCause();
+                if (cause instanceof UncheckedIOException uncheckedIOException) {
+                    throw uncheckedIOException.getCause();
+                }
+                throw new IOException("Failed to stream Prometheus scrape", cause);
+            }
+        }
     }
 }

--- a/micrometer-registry-prometheus/src/test/groovy/io/micronaut/configuration/metrics/micrometer/prometheus/management/PrometheusEndpointSpec.groovy
+++ b/micrometer-registry-prometheus/src/test/groovy/io/micronaut/configuration/metrics/micrometer/prometheus/management/PrometheusEndpointSpec.groovy
@@ -25,7 +25,7 @@ class PrometheusEndpointSpec extends Specification {
     @AutoCleanup('shutdownNow')
     ExecutorService scrapeExecutor = Executors.newSingleThreadExecutor()
 
-    def setup() {
+    def setupSpec() {
         def registry = embeddedServer.applicationContext.getBean(MeterRegistry)
 
         new JvmMemoryMetrics().bindTo(registry)

--- a/micrometer-registry-prometheus/src/test/groovy/io/micronaut/configuration/metrics/micrometer/prometheus/management/PrometheusEndpointSpec.groovy
+++ b/micrometer-registry-prometheus/src/test/groovy/io/micronaut/configuration/metrics/micrometer/prometheus/management/PrometheusEndpointSpec.groovy
@@ -15,9 +15,11 @@ import spock.lang.Specification
 import java.io.IOException
 import java.io.OutputStream
 import java.nio.charset.StandardCharsets
+import java.util.concurrent.CancellationException
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
+import java.util.concurrent.Future
 import java.util.concurrent.RejectedExecutionException
 import java.util.concurrent.TimeUnit
 
@@ -168,6 +170,63 @@ class PrometheusEndpointSpec extends Specification {
             throw failure
         }
         0 * registry.scrape()
+    }
+
+    void "test prometheus scrape stream ignores producer cancellation when awaiting completion"() {
+        given:
+        def registry = Mock(PrometheusMeterRegistry)
+        def executor = Mock(ExecutorService)
+        Future<?> future = Mock()
+        def endpoint = new PrometheusEndpoint(registry, executor)
+
+        when:
+        String result
+        endpoint.scrapeStream().withCloseable { inputStream ->
+            result = inputStream.getText(StandardCharsets.UTF_8.name())
+        }
+
+        then:
+        result == 'jvm_memory_used 1.0\n'
+        1 * executor.submit(_ as Runnable) >> { Runnable task ->
+            task.run()
+            future
+        }
+        1 * registry.scrape(_ as OutputStream) >> { OutputStream outputStream ->
+            outputStream.write('jvm_memory_used 1.0\n'.getBytes(StandardCharsets.UTF_8))
+        }
+        1 * future.get() >> { throw new CancellationException('cancelled') }
+        0 * registry.scrape()
+    }
+
+    void "test prometheus scrape stream restores interrupt when awaiting producer completion"() {
+        given:
+        def registry = Mock(PrometheusMeterRegistry)
+        def executor = Mock(ExecutorService)
+        Future<?> future = Mock()
+        def endpoint = new PrometheusEndpoint(registry, executor)
+
+        when:
+        endpoint.scrapeStream().withCloseable { inputStream ->
+            inputStream.getText(StandardCharsets.UTF_8.name())
+        }
+
+        then:
+        def exception = thrown(IOException)
+        exception.message == 'Interrupted while streaming Prometheus scrape'
+        exception.cause instanceof InterruptedException
+        Thread.currentThread().isInterrupted()
+        1 * executor.submit(_ as Runnable) >> { Runnable task ->
+            task.run()
+            future
+        }
+        1 * registry.scrape(_ as OutputStream) >> { OutputStream outputStream ->
+            outputStream.write('jvm_memory_used 1.0\n'.getBytes(StandardCharsets.UTF_8))
+        }
+        1 * future.get() >> { throw new InterruptedException('boom') }
+        0 * registry.scrape()
+
+        cleanup:
+        Thread.interrupted()
     }
 
     void "test prometheus scrape stream propagates scheduling failures"() {

--- a/micrometer-registry-prometheus/src/test/groovy/io/micronaut/configuration/metrics/micrometer/prometheus/management/PrometheusEndpointSpec.groovy
+++ b/micrometer-registry-prometheus/src/test/groovy/io/micronaut/configuration/metrics/micrometer/prometheus/management/PrometheusEndpointSpec.groovy
@@ -12,10 +12,13 @@ import spock.lang.PendingFeature
 import spock.lang.Shared
 import spock.lang.Specification
 
+import java.io.IOException
 import java.io.OutputStream
 import java.nio.charset.StandardCharsets
+import java.util.concurrent.CountDownLatch
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
 
 class PrometheusEndpointSpec extends Specification {
     @AutoCleanup('shutdownNow')
@@ -51,7 +54,7 @@ class PrometheusEndpointSpec extends Specification {
 
         when:
         String result
-        endpoint.scrape().withCloseable { inputStream ->
+        endpoint.scrapeStream().withCloseable { inputStream ->
             result = inputStream.getText(StandardCharsets.UTF_8.name())
         }
 
@@ -59,6 +62,66 @@ class PrometheusEndpointSpec extends Specification {
         result == 'jvm_memory_used 1.0\n'
         1 * registry.scrape(_ as OutputStream) >> { OutputStream outputStream ->
             outputStream.write('jvm_memory_used 1.0\n'.getBytes(StandardCharsets.UTF_8))
+        }
+        0 * registry.scrape()
+    }
+
+    void "test prometheus scrape retains direct string access"() {
+        given:
+        def registry = Mock(PrometheusMeterRegistry)
+        def endpoint = new PrometheusEndpoint(registry, scrapeExecutor)
+
+        when:
+        String result = endpoint.scrape()
+
+        then:
+        result == 'jvm_memory_used 1.0\n'
+        1 * registry.scrape() >> 'jvm_memory_used 1.0\n'
+        0 * registry.scrape(_ as OutputStream)
+    }
+
+    void "test prometheus scrape stream propagates producer io failure"() {
+        given:
+        def registry = Mock(PrometheusMeterRegistry)
+        def endpoint = new PrometheusEndpoint(registry, scrapeExecutor)
+        def failure = new IOException('boom')
+
+        when:
+        endpoint.scrapeStream().withCloseable { inputStream ->
+            inputStream.getText(StandardCharsets.UTF_8.name())
+        }
+
+        then:
+        def exception = thrown(IOException)
+        exception.is(failure)
+        1 * registry.scrape(_ as OutputStream) >> { OutputStream outputStream ->
+            throw failure
+        }
+        0 * registry.scrape()
+    }
+
+    void "test prometheus scrape stream cancels producer when consumer closes early"() {
+        given:
+        def registry = Mock(PrometheusMeterRegistry)
+        def endpoint = new PrometheusEndpoint(registry, scrapeExecutor)
+        def started = new CountDownLatch(1)
+        def interrupted = new CountDownLatch(1)
+
+        when:
+        def inputStream = endpoint.scrapeStream()
+        assert started.await(5, TimeUnit.SECONDS)
+        inputStream.close()
+
+        then:
+        interrupted.await(5, TimeUnit.SECONDS)
+        1 * registry.scrape(_ as OutputStream) >> { OutputStream outputStream ->
+            started.countDown()
+            try {
+                Thread.sleep(30_000)
+            } catch (InterruptedException ignored) {
+                interrupted.countDown()
+                Thread.currentThread().interrupt()
+            }
         }
         0 * registry.scrape()
     }

--- a/micrometer-registry-prometheus/src/test/groovy/io/micronaut/configuration/metrics/micrometer/prometheus/management/PrometheusEndpointSpec.groovy
+++ b/micrometer-registry-prometheus/src/test/groovy/io/micronaut/configuration/metrics/micrometer/prometheus/management/PrometheusEndpointSpec.groovy
@@ -18,6 +18,7 @@ import java.nio.charset.StandardCharsets
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
+import java.util.concurrent.RejectedExecutionException
 import java.util.concurrent.TimeUnit
 
 class PrometheusEndpointSpec extends Specification {
@@ -69,7 +70,7 @@ class PrometheusEndpointSpec extends Specification {
     void "test prometheus scrape retains direct string access"() {
         given:
         def registry = Mock(PrometheusMeterRegistry)
-        def endpoint = new PrometheusEndpoint(registry, scrapeExecutor)
+        def endpoint = new PrometheusEndpoint(registry)
 
         when:
         String result = endpoint.scrape()
@@ -100,6 +101,28 @@ class PrometheusEndpointSpec extends Specification {
         0 * registry.scrape()
     }
 
+    void "test prometheus scrape stream supports single byte reads"() {
+        given:
+        def registry = Mock(PrometheusMeterRegistry)
+        def endpoint = new PrometheusEndpoint(registry, scrapeExecutor)
+
+        when:
+        def bytes = []
+        endpoint.scrapeStream().withCloseable { inputStream ->
+            int nextByte
+            while ((nextByte = inputStream.read()) != -1) {
+                bytes << nextByte
+            }
+        }
+
+        then:
+        new String((byte[]) bytes, StandardCharsets.UTF_8) == 'abc'
+        1 * registry.scrape(_ as OutputStream) >> { OutputStream outputStream ->
+            outputStream.write('abc'.getBytes(StandardCharsets.UTF_8))
+        }
+        0 * registry.scrape()
+    }
+
     void "test prometheus scrape stream cancels producer when consumer closes early"() {
         given:
         def registry = Mock(PrometheusMeterRegistry)
@@ -124,6 +147,44 @@ class PrometheusEndpointSpec extends Specification {
             }
         }
         0 * registry.scrape()
+    }
+
+    void "test prometheus scrape stream wraps non io producer failure"() {
+        given:
+        def registry = Mock(PrometheusMeterRegistry)
+        def endpoint = new PrometheusEndpoint(registry, scrapeExecutor)
+        def failure = new IllegalStateException('boom')
+
+        when:
+        endpoint.scrapeStream().withCloseable { inputStream ->
+            inputStream.getText(StandardCharsets.UTF_8.name())
+        }
+
+        then:
+        def exception = thrown(IOException)
+        exception.message == 'Failed to stream Prometheus scrape'
+        exception.cause.is(failure)
+        1 * registry.scrape(_ as OutputStream) >> { OutputStream outputStream ->
+            throw failure
+        }
+        0 * registry.scrape()
+    }
+
+    void "test prometheus scrape stream propagates scheduling failures"() {
+        given:
+        def registry = Mock(PrometheusMeterRegistry)
+        def executor = Mock(ExecutorService)
+        def endpoint = new PrometheusEndpoint(registry, executor)
+        def failure = new RejectedExecutionException('boom')
+
+        when:
+        endpoint.scrapeStream()
+
+        then:
+        def exception = thrown(RejectedExecutionException)
+        exception.is(failure)
+        1 * executor.submit(_ as Runnable) >> { throw failure }
+        0 * registry._
     }
 
     @PendingFeature

--- a/micrometer-registry-prometheus/src/test/groovy/io/micronaut/configuration/metrics/micrometer/prometheus/management/PrometheusEndpointSpec.groovy
+++ b/micrometer-registry-prometheus/src/test/groovy/io/micronaut/configuration/metrics/micrometer/prometheus/management/PrometheusEndpointSpec.groovy
@@ -1,6 +1,7 @@
 package io.micronaut.configuration.metrics.micrometer.prometheus.management
 
 import io.micrometer.core.instrument.MeterRegistry
+import io.micrometer.prometheusmetrics.PrometheusMeterRegistry
 import io.micrometer.core.instrument.binder.jvm.JvmMemoryMetrics
 import io.micrometer.core.instrument.binder.system.ProcessorMetrics
 import io.micronaut.context.ApplicationContext
@@ -11,7 +12,14 @@ import spock.lang.PendingFeature
 import spock.lang.Shared
 import spock.lang.Specification
 
+import java.io.OutputStream
+import java.nio.charset.StandardCharsets
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
+
 class PrometheusEndpointSpec extends Specification {
+    @AutoCleanup('shutdownNow')
+    ExecutorService scrapeExecutor = Executors.newSingleThreadExecutor()
 
     def setup() {
         def registry = embeddedServer.applicationContext.getBean(MeterRegistry)
@@ -34,6 +42,25 @@ class PrometheusEndpointSpec extends Specification {
     void "test prometheus scrape"() {
         expect:
         client.toBlocking().retrieve('/prometheus').contains('jvm_memory_used')
+    }
+
+    void "test prometheus scrape streams output"() {
+        given:
+        def registry = Mock(PrometheusMeterRegistry)
+        def endpoint = new PrometheusEndpoint(registry, scrapeExecutor)
+
+        when:
+        String result
+        endpoint.scrape().withCloseable { inputStream ->
+            result = inputStream.getText(StandardCharsets.UTF_8.name())
+        }
+
+        then:
+        result == 'jvm_memory_used 1.0\n'
+        1 * registry.scrape(_ as OutputStream) >> { OutputStream outputStream ->
+            outputStream.write('jvm_memory_used 1.0\n'.getBytes(StandardCharsets.UTF_8))
+        }
+        0 * registry.scrape()
     }
 
     @PendingFeature


### PR DESCRIPTION
## Summary
- stream the Prometheus endpoint response through `scrape(OutputStream)` instead of materializing the full payload as a `String`
- run the scrape writer on the blocking executor and propagate producer failures through the returned `InputStream`
- retain direct string scrape access for compatibility while exposing the streamed endpoint response
- add regression coverage for streamed output, producer failures, cancellation, interrupts, executor rejection, and early close behavior

## Testing
- `./gradlew :micronaut-micrometer-registry-prometheus:test --tests io.micronaut.configuration.metrics.micrometer.prometheus.management.PrometheusEndpointSpec`

Resolves https://github.com/micronaut-projects/micronaut-micrometer/issues/1000
