### PR TITLE
Record metrics for security short-circuit responses

### DIFF
--- a/micrometer-core/src/main/java/io/micronaut/configuration/metrics/binder/web/ServerMetricsFilter.java
+++ b/micrometer-core/src/main/java/io/micronaut/configuration/metrics/binder/web/ServerMetricsFilter.java
@@ -21,6 +21,7 @@ import io.micronaut.configuration.metrics.binder.web.config.HttpMetricsConfig;
 import io.micronaut.configuration.metrics.binder.web.config.HttpServerMeterConfig;
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.order.Ordered;
 import io.micronaut.core.util.SupplierUtil;
 import io.micronaut.http.HttpAttributes;
 import io.micronaut.http.HttpRequest;
@@ -28,6 +29,7 @@ import io.micronaut.http.HttpResponse;
 import io.micronaut.http.annotation.RequestFilter;
 import io.micronaut.http.annotation.ResponseFilter;
 import io.micronaut.http.annotation.ServerFilter;
+import io.micronaut.http.filter.ServerFilterPhase;
 import io.micronaut.web.router.UriRouteMatch;
 import jakarta.inject.Provider;
 
@@ -50,7 +52,7 @@ import static io.micronaut.core.util.StringUtils.FALSE;
 @Requires(property = HttpMetricsConfig.ENABLED, notEquals = FALSE)
 @Requires(condition = WebMetricsServerCondition.class)
 @Internal
-final class ServerMetricsFilter {
+final class ServerMetricsFilter implements Ordered {
 
     private static final String START_ATTRIBUTE = ServerMetricsFilter.class.getName() + ".START_ATTRIBUTE";
     private static final String UNMATCHED_URI = "UNMATCHED_URI";
@@ -65,6 +67,11 @@ final class ServerMetricsFilter {
     public ServerMetricsFilter(Provider<MeterRegistry> meterRegistryProvider, HttpMetricsConfig.ClientErrorsUrisConfig clientErrorsUrisConfig) {
         this.meterRegistryProvider = SupplierUtil.memoized(meterRegistryProvider::get);
         this.reportClientErrorURIs = clientErrorsUrisConfig.enabled();
+    }
+
+    @Override
+    public int getOrder() {
+        return ServerFilterPhase.METRICS.order();
     }
 
     private String resolvePath(HttpRequest<?> request) {

--- a/micrometer-core/src/test/groovy/io/micronaut/configuration/metrics/binder/web/HttpMetricsSpec.groovy
+++ b/micrometer-core/src/test/groovy/io/micronaut/configuration/metrics/binder/web/HttpMetricsSpec.groovy
@@ -11,13 +11,21 @@ import io.micronaut.configuration.metrics.binder.web.config.HttpClientMeterConfi
 import io.micronaut.configuration.metrics.binder.web.config.HttpServerMeterConfig
 import io.micronaut.context.ApplicationContext
 import io.micronaut.context.annotation.Requires
+import io.micronaut.core.order.Ordered
 import io.micronaut.core.util.CollectionUtils
+import io.micronaut.http.HttpRequest
 import io.micronaut.http.HttpResponse
+import io.micronaut.http.HttpStatus
 import io.micronaut.http.annotation.Controller
 import io.micronaut.http.annotation.Error
+import io.micronaut.http.annotation.Filter
 import io.micronaut.http.annotation.Get
 import io.micronaut.http.client.annotation.Client
 import io.micronaut.http.client.exceptions.HttpClientResponseException
+import io.micronaut.http.filter.HttpServerFilter
+import io.micronaut.http.filter.ServerFilterPhase
+import io.micronaut.http.filter.ServerFilterChain
+import io.micronaut.http.exceptions.HttpStatusException
 import io.micronaut.http.uri.UriBuilder
 import io.micronaut.runtime.server.EmbeddedServer
 import io.micronaut.websocket.WebSocketBroadcaster
@@ -217,6 +225,33 @@ class HttpMetricsSpec extends Specification {
         embeddedServer.close()
     }
 
+    void "test server metrics record security-style short-circuit 401 and 403 responses"() {
+        given:
+        EmbeddedServer embeddedServer = ApplicationContext.run(EmbeddedServer, [
+                'spec.name': getClass().getSimpleName()
+        ])
+        def context = embeddedServer.applicationContext
+        TestClient client = context.getBean(TestClient)
+        MeterRegistry registry = context.getBean(MeterRegistry)
+
+        when:
+        client.unauthorized()
+
+        then:
+        thrown(HttpClientResponseException)
+        registry.get(HttpServerMeterConfig.REQUESTS_METRIC).tags("status", "401", "uri", "/test-http-metrics/unauthorized").timer().count() == 1
+
+        when:
+        client.forbidden()
+
+        then:
+        thrown(HttpClientResponseException)
+        registry.get(HttpServerMeterConfig.REQUESTS_METRIC).tags("status", "403", "uri", "/test-http-metrics/forbidden").timer().count() == 1
+
+        cleanup:
+        embeddedServer.close()
+    }
+
     void "test getting the beans #cfg #setting"() {
         when:
         ApplicationContext context = ApplicationContext.run([(cfg): setting, 'spec.name': getClass().getSimpleName()])
@@ -234,6 +269,17 @@ class HttpMetricsSpec extends Specification {
         MICRONAUT_METRICS_ENABLED     | false
         (WebMetricsPublisher.ENABLED) | true
         (WebMetricsPublisher.ENABLED) | false
+    }
+
+    void "test server metrics filter uses metrics phase order"() {
+        when:
+        ApplicationContext context = ApplicationContext.run(['spec.name': getClass().getSimpleName()])
+
+        then:
+        context.getBean(ServerMetricsFilter).getOrder() == ServerFilterPhase.METRICS.order()
+
+        cleanup:
+        context.close()
     }
 
     @PendingFeature
@@ -294,6 +340,12 @@ class HttpMetricsSpec extends Specification {
         @Get("/test-http-metrics/exception-handling")
         HttpResponse exceptionHandling()
 
+        @Get("/test-http-metrics/unauthorized")
+        HttpResponse unauthorized()
+
+        @Get("/test-http-metrics/forbidden")
+        HttpResponse forbidden()
+
         @Get("/test-http-metrics-not-found")
         HttpResponse notFound()
     }
@@ -325,9 +377,36 @@ class HttpMetricsSpec extends Specification {
             throw new MyException("my custom exception")
         }
 
+        @Get("/test-http-metrics/unauthorized")
+        String unauthorized() { "unauthorized" }
+
+        @Get("/test-http-metrics/forbidden")
+        String forbidden() { "forbidden" }
+
         @Error(exception = MyException)
         HttpResponse<?> myExceptionHandler() {
             return HttpResponse.badRequest()
+        }
+    }
+
+    @Requires(property = "spec.name", value = "HttpMetricsSpec")
+    @Filter("/test-http-metrics/**")
+    static class SecurityShortCircuitFilter implements HttpServerFilter, Ordered {
+
+        @Override
+        int getOrder() {
+            return ServerFilterPhase.SECURITY.order()
+        }
+
+        @Override
+        Publisher<io.micronaut.http.MutableHttpResponse<?>> doFilter(HttpRequest<?> request, ServerFilterChain chain) {
+            if (request.path == "/test-http-metrics/unauthorized") {
+                throw new HttpStatusException(HttpStatus.UNAUTHORIZED, "unauthorized")
+            }
+            if (request.path == "/test-http-metrics/forbidden") {
+                throw new HttpStatusException(HttpStatus.FORBIDDEN, "forbidden")
+            }
+            return chain.proceed(request)
         }
     }
 


### PR DESCRIPTION
## Summary
- make `ServerMetricsFilter` implement `Ordered` and run in the metrics filter phase
- add regression coverage for 401 and 403 responses short-circuited by a security-style server filter
- verify the filter exposes the expected metrics phase ordering

## Verification
- `./gradlew :micronaut-micrometer-core:test --tests io.micronaut.configuration.metrics.binder.web.HttpMetricsSpec`

Resolves #970
