### PR TITLE
Add handled exception metrics regression coverage

### DIFF
--- a/micrometer-core/src/test/java/io/micronaut/configuration/metrics/WebMetricsExceptionCodeTest.java
+++ b/micrometer-core/src/test/java/io/micronaut/configuration/metrics/WebMetricsExceptionCodeTest.java
@@ -39,6 +39,21 @@ class WebMetricsExceptionCodeTest {
         Assertions.assertEquals(1, count);
     }
 
+    @Test
+    void testWebMetricsBadRequestStatusCode(@Client("/") HttpClient httpClient, MeterRegistry meterRegistry) {
+        BlockingHttpClient client = httpClient.toBlocking();
+        HttpClientResponseException e = Assertions.assertThrows(HttpClientResponseException.class, () -> client.exchange("/metrics/bad-request"));
+        Assertions.assertEquals(HttpStatus.BAD_REQUEST, e.getStatus());
+        Assertions.assertEquals("Client '/': Bad Request", e.getMessage());
+        long count = meterRegistry.timer("http.server.requests", List.of(
+            Tag.of("method", "GET"),
+            Tag.of("uri", "/metrics/bad-request"),
+            Tag.of("status", "400"),
+            Tag.of("exception", "BadRequestException")
+        )).count();
+        Assertions.assertEquals(1, count);
+    }
+
     @Controller("/metrics")
     @Requires(property = "spec.name", value = "WebMetricsStatusCodeTest")
     static class WebMetricsCustomStatusCodeController {
@@ -47,10 +62,21 @@ class WebMetricsExceptionCodeTest {
         String test() {
             throw new GatewayTimeoutException("GATEWAY TIMEOUT");
         }
+
+        @Get("/bad-request")
+        String badRequest() {
+            throw new BadRequestException("BAD REQUEST");
+        }
     }
 
     static class GatewayTimeoutException extends RuntimeException {
         public GatewayTimeoutException(String message) {
+            super(message);
+        }
+    }
+
+    static class BadRequestException extends RuntimeException {
+        public BadRequestException(String message) {
             super(message);
         }
     }
@@ -63,6 +89,18 @@ class WebMetricsExceptionCodeTest {
         @Override
         public HttpResponse<?> handle(HttpRequest request, GatewayTimeoutException exception) {
             return HttpResponse.status(HttpStatus.GATEWAY_TIMEOUT)
+                .body(exception.getMessage());
+        }
+    }
+
+    @Produces
+    @Singleton
+    @Requires(property = "spec.name", value = "WebMetricsStatusCodeTest")
+    static class BadRequestExceptionHandler implements ExceptionHandler<BadRequestException, HttpResponse<?>> {
+
+        @Override
+        public HttpResponse<?> handle(HttpRequest request, BadRequestException exception) {
+            return HttpResponse.status(HttpStatus.BAD_REQUEST)
                 .body(exception.getMessage());
         }
     }

--- a/micrometer-core/src/test/java/io/micronaut/configuration/metrics/WebMetricsExceptionCodeTest.java
+++ b/micrometer-core/src/test/java/io/micronaut/configuration/metrics/WebMetricsExceptionCodeTest.java
@@ -2,6 +2,7 @@ package io.micronaut.configuration.metrics;
 
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.Timer;
 import io.micronaut.context.annotation.Property;
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.core.util.StringUtils;
@@ -44,7 +45,6 @@ class WebMetricsExceptionCodeTest {
         BlockingHttpClient client = httpClient.toBlocking();
         HttpClientResponseException e = Assertions.assertThrows(HttpClientResponseException.class, () -> client.exchange("/metrics/bad-request"));
         Assertions.assertEquals(HttpStatus.BAD_REQUEST, e.getStatus());
-        Assertions.assertEquals("Client '/': Bad Request", e.getMessage());
         long count = meterRegistry.timer("http.server.requests", List.of(
             Tag.of("method", "GET"),
             Tag.of("uri", "/metrics/bad-request"),
@@ -52,6 +52,16 @@ class WebMetricsExceptionCodeTest {
             Tag.of("exception", "BadRequestException")
         )).count();
         Assertions.assertEquals(1, count);
+
+        Timer fallbackTimer = meterRegistry.find("http.server.requests")
+            .tags(List.of(
+                Tag.of("method", "GET"),
+                Tag.of("uri", "/metrics/bad-request"),
+                Tag.of("status", "500"),
+                Tag.of("exception", "BadRequestException")
+            ))
+            .timer();
+        Assertions.assertTrue(fallbackTimer == null || fallbackTimer.count() == 0);
     }
 
     @Controller("/metrics")

--- a/micrometer-observation-http/src/test/groovy/io/micronaut/micrometer/observation/ObservationHttpHandledExceptionMetricsSpec.groovy
+++ b/micrometer-observation-http/src/test/groovy/io/micronaut/micrometer/observation/ObservationHttpHandledExceptionMetricsSpec.groovy
@@ -1,0 +1,101 @@
+package io.micronaut.micrometer.observation
+
+import io.micrometer.core.instrument.MeterRegistry
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.annotation.Factory
+import io.micronaut.context.annotation.Primary
+import io.micronaut.context.annotation.Requires
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.HttpResponse
+import io.micronaut.http.HttpStatus
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Get
+import io.micronaut.http.client.HttpClient
+import io.micronaut.http.client.exceptions.HttpClientResponseException
+import io.micronaut.http.server.exceptions.ExceptionHandler
+import io.micronaut.http.annotation.Produces
+import io.micronaut.runtime.server.EmbeddedServer
+import jakarta.inject.Singleton
+import spock.lang.AutoCleanup
+import spock.lang.Specification
+
+class ObservationHttpHandledExceptionMetricsSpec extends Specification {
+
+    @AutoCleanup
+    private ApplicationContext context
+
+    @AutoCleanup
+    private EmbeddedServer embeddedServer
+
+    @AutoCleanup
+    private HttpClient httpClient
+
+    private MeterRegistry meterRegistry
+
+    void setup() {
+        context = ApplicationContext.builder(
+            'micronaut.application.name': 'test-app',
+            'spec.name': 'ObservationHttpHandledExceptionMetricsSpec'
+        ).start()
+
+        embeddedServer = context.getBean(EmbeddedServer).start()
+        httpClient = HttpClient.create(embeddedServer.URL)
+        meterRegistry = embeddedServer.applicationContext.getBean(MeterRegistry)
+    }
+
+    void 'handled exceptions keep the response status in http.server.requests'() {
+        when:
+        httpClient.toBlocking().exchange(HttpRequest.GET('/metrics/test'))
+
+        then:
+        HttpClientResponseException exception = thrown()
+        exception.status == HttpStatus.BAD_REQUEST
+        meterRegistry.find('http.server.requests')
+            .tags('method', 'GET', 'uri', '/metrics/test', 'status', '400')
+            .timers()
+            .size() == 1
+        meterRegistry.find('http.server.requests')
+            .tags('method', 'GET', 'uri', '/metrics/test', 'status', '500')
+            .timers()
+            .isEmpty()
+    }
+
+    @Controller('/metrics')
+    @Requires(property = 'spec.name', value = 'ObservationHttpHandledExceptionMetricsSpec')
+    static class TestController {
+
+        @Get('/test')
+        String test() {
+            throw new GenericException('BAD REQUEST')
+        }
+    }
+
+    @Produces
+    @Singleton
+    @Requires(property = 'spec.name', value = 'ObservationHttpHandledExceptionMetricsSpec')
+    static class GenericExceptionHandler implements ExceptionHandler<GenericException, HttpResponse<?>> {
+
+        @Override
+        HttpResponse<String> handle(HttpRequest<?> request, GenericException exception) {
+            HttpResponse.badRequest('BAD REQUEST FROM HANDLER')
+        }
+    }
+
+    static class GenericException extends RuntimeException {
+        GenericException(String message) {
+            super(message)
+        }
+    }
+
+    @Factory
+    @Requires(property = 'spec.name', value = 'ObservationHttpHandledExceptionMetricsSpec')
+    static class TestFactory {
+
+        @Singleton
+        @Primary
+        MeterRegistry meterRegistry() {
+            new SimpleMeterRegistry()
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add regression coverage for handled exception HTTP server metrics
- verify handled bad request responses are recorded with status 400 instead of a fallback 500 timer
- cover both core web metrics and observation HTTP metrics paths

## Verification
- ./gradlew :micronaut-micrometer-core:test --tests io.micronaut.configuration.metrics.WebMetricsExceptionCodeTest --rerun-tasks
- ./gradlew :micronaut-micrometer-observation-http:test --tests io.micronaut.micrometer.observation.ObservationHttpHandledExceptionMetricsSpec

Resolves https://github.com/micronaut-projects/micronaut-micrometer/issues/937
