### PR TITLE
Fix R2DBC metrics binder without r2dbc-pool

### DIFF
--- a/micrometer-core/src/main/java/io/micronaut/configuration/metrics/binder/r2dbc/R2dbcPoolMetricsBinder.java
+++ b/micrometer-core/src/main/java/io/micronaut/configuration/metrics/binder/r2dbc/R2dbcPoolMetricsBinder.java
@@ -19,8 +19,8 @@ import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.binder.MeterBinder;
-import org.jspecify.annotations.NonNull;
 import io.r2dbc.pool.PoolMetrics;
+import org.jspecify.annotations.NonNull;
 
 import java.util.function.Function;
 

--- a/micrometer-core/src/main/java/io/micronaut/configuration/metrics/binder/r2dbc/R2dbcPoolMetricsBinderFactory.java
+++ b/micrometer-core/src/main/java/io/micronaut/configuration/metrics/binder/r2dbc/R2dbcPoolMetricsBinderFactory.java
@@ -39,6 +39,7 @@ import static io.micronaut.core.util.StringUtils.FALSE;
  */
 @Factory
 @RequiresMetrics
+@Requires(classes = ConnectionPool.class)
 @Requires(property = MICRONAUT_METRICS_BINDERS + ".r2dbc.enabled", notEquals = FALSE)
 public class R2dbcPoolMetricsBinderFactory {
 
@@ -57,7 +58,6 @@ public class R2dbcPoolMetricsBinderFactory {
         if (factory instanceof ConnectionPool) {
             poolMetrics = ((ConnectionPool) factory).getMetrics().orElse(null);
         }
-
         return new R2dbcPoolMetricsBinder(poolMetrics, dataSourceName, Collections.emptyList());
     }
 }

--- a/micrometer-core/src/test/groovy/io/micronaut/configuration/metrics/binder/r2dbc/R2dbcPoolMetricsBinderFactorySpec.groovy
+++ b/micrometer-core/src/test/groovy/io/micronaut/configuration/metrics/binder/r2dbc/R2dbcPoolMetricsBinderFactorySpec.groovy
@@ -1,5 +1,6 @@
 package io.micronaut.configuration.metrics.binder.r2dbc
 
+import io.micronaut.context.ApplicationContext
 import io.r2dbc.pool.ConnectionPool
 import io.r2dbc.pool.PoolMetrics
 import io.r2dbc.spi.Connection
@@ -7,6 +8,9 @@ import io.r2dbc.spi.ConnectionFactory
 import io.r2dbc.spi.ConnectionFactoryMetadata
 import org.reactivestreams.Publisher
 import spock.lang.Specification
+
+import java.net.URL
+import java.net.URLClassLoader
 
 class R2dbcPoolMetricsBinderFactorySpec extends Specification {
 
@@ -49,6 +53,30 @@ class R2dbcPoolMetricsBinderFactorySpec extends Specification {
         meterBinder.@poolMetrics == null
     }
 
+    void "test starting context without r2dbc pool on classpath"() {
+        given:
+        def originalClassLoader = Thread.currentThread().contextClassLoader
+        def classLoader = new FilteringClassLoader(originalClassLoader)
+        ApplicationContext context = ApplicationContext.builder()
+            .classLoader(classLoader)
+            .build()
+
+        Thread.currentThread().contextClassLoader = classLoader
+
+        when:
+        context.registerSingleton(ConnectionFactory, new StubFactory())
+        context.start()
+
+        then:
+        noExceptionThrown()
+        !context.containsBean(R2dbcPoolMetricsBinderFactory)
+        !context.containsBean(R2dbcPoolMetricsBinder)
+
+        cleanup:
+        context?.close()
+        Thread.currentThread().contextClassLoader = originalClassLoader
+    }
+
     class StubFactory implements ConnectionFactory {
         Publisher<? extends Connection> create() { null }
         ConnectionFactoryMetadata getMetadata() { null }
@@ -61,5 +89,42 @@ class R2dbcPoolMetricsBinderFactorySpec extends Specification {
         int pendingAcquireSize() { 0 }
         int getMaxAllocatedSize() { 0 }
         int getMaxPendingAcquireSize() { 0 }
+    }
+
+    private static final class FilteringClassLoader extends URLClassLoader {
+
+        private static final String BINDER_PACKAGE = "io.micronaut.configuration.metrics.binder.r2dbc."
+
+        FilteringClassLoader(ClassLoader parent) {
+            super(classpathUrls(), parent)
+        }
+
+        @Override
+        protected synchronized Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+            if (name.startsWith("io.r2dbc.pool.")) {
+                throw new ClassNotFoundException(name)
+            }
+            Class<?> loadedClass = findLoadedClass(name)
+            if (loadedClass == null && name.startsWith(BINDER_PACKAGE)) {
+                try {
+                    loadedClass = findClass(name)
+                } catch (ClassNotFoundException ignored) {
+                    loadedClass = super.loadClass(name, false)
+                }
+            } else if (loadedClass == null) {
+                loadedClass = super.loadClass(name, false)
+            }
+            if (resolve) {
+                resolveClass(loadedClass)
+            }
+            return loadedClass
+        }
+
+        private static URL[] classpathUrls() {
+            System.getProperty("java.class.path")
+                .split(File.pathSeparator)
+                .findAll { !it.contains("r2dbc-pool") }
+                .collect { new File(it).toURI().toURL() } as URL[]
+        }
     }
 }

--- a/micrometer-core/src/test/groovy/io/micronaut/configuration/metrics/binder/r2dbc/R2dbcPoolMetricsBinderFactorySpec.groovy
+++ b/micrometer-core/src/test/groovy/io/micronaut/configuration/metrics/binder/r2dbc/R2dbcPoolMetricsBinderFactorySpec.groovy
@@ -69,12 +69,13 @@ class R2dbcPoolMetricsBinderFactorySpec extends Specification {
 
         then:
         noExceptionThrown()
-        !context.containsBean(R2dbcPoolMetricsBinderFactory)
-        !context.containsBean(R2dbcPoolMetricsBinder)
+        !context.containsBean(classLoader.loadClass('io.micronaut.configuration.metrics.binder.r2dbc.R2dbcPoolMetricsBinderFactory'))
+        !context.containsBean(classLoader.loadClass('io.micronaut.configuration.metrics.binder.r2dbc.R2dbcPoolMetricsBinder'))
 
         cleanup:
         context?.close()
         Thread.currentThread().contextClassLoader = originalClassLoader
+        classLoader?.close()
     }
 
     class StubFactory implements ConnectionFactory {


### PR DESCRIPTION
## Summary
- only create the R2DBC pool metrics binder when `io.r2dbc.pool.ConnectionPool` is on the classpath
- add a regression test that starts the application context without `r2dbc-pool` present

## Test
- not run (approved local changes)

Resolves #407
