### PR TITLE
Support common-tags alias for Micrometer common tags

### DIFF
--- a/micrometer-core/src/main/java/io/micronaut/configuration/metrics/common/tags/CommonTagsCondition.java
+++ b/micrometer-core/src/main/java/io/micronaut/configuration/metrics/common/tags/CommonTagsCondition.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.configuration.metrics.common.tags;
+
+import io.micronaut.context.condition.Condition;
+import io.micronaut.context.condition.ConditionContext;
+
+import static io.micronaut.configuration.metrics.micrometer.MeterRegistryFactory.MICRONAUT_METRICS_COMMON_TAGS;
+import static io.micronaut.configuration.metrics.micrometer.MeterRegistryFactory.MICRONAUT_METRICS_TAGS;
+
+/**
+ * Activates common tag configuration when either supported property prefix is configured.
+ */
+public final class CommonTagsCondition implements Condition {
+
+    @Override
+    public boolean matches(ConditionContext context) {
+        return containsConfiguredTags(context, MICRONAUT_METRICS_TAGS)
+            || containsConfiguredTags(context, MICRONAUT_METRICS_COMMON_TAGS);
+    }
+
+    private static boolean containsConfiguredTags(ConditionContext context, String property) {
+        return context.containsProperty(property) || context.containsProperties(property);
+    }
+}

--- a/micrometer-core/src/main/java/io/micronaut/configuration/metrics/common/tags/CommonTagsCondition.java
+++ b/micrometer-core/src/main/java/io/micronaut/configuration/metrics/common/tags/CommonTagsCondition.java
@@ -32,7 +32,7 @@ public final class CommonTagsCondition implements Condition {
             || containsConfiguredTags(context, MICRONAUT_METRICS_COMMON_TAGS);
     }
 
-    private static boolean containsConfiguredTags(ConditionContext context, String property) {
+    private static boolean containsConfiguredTags(ConditionContext<?> context, String property) {
         return context.containsProperty(property) || context.containsProperties(property);
     }
 }

--- a/micrometer-core/src/main/java/io/micronaut/configuration/metrics/common/tags/CommonTagsConfigurer.java
+++ b/micrometer-core/src/main/java/io/micronaut/configuration/metrics/common/tags/CommonTagsConfigurer.java
@@ -19,30 +19,36 @@ import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tag;
 import io.micronaut.configuration.metrics.aggregator.MeterRegistryConfigurer;
 import io.micronaut.configuration.metrics.annotation.RequiresMetrics;
-import io.micronaut.configuration.metrics.micrometer.ExportConfigurationProperties;
 import io.micronaut.context.annotation.Factory;
 import io.micronaut.context.annotation.Requires;
+import io.micronaut.context.env.Environment;
+import io.micronaut.core.naming.conventions.StringConvention;
 
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Properties;
+import java.util.Map;
+import java.util.TreeMap;
 
 import static io.micronaut.configuration.metrics.micrometer.MeterRegistryFactory.MICRONAUT_METRICS_COMMON_TAGS;
+import static io.micronaut.configuration.metrics.micrometer.MeterRegistryFactory.MICRONAUT_METRICS_TAGS;
 
 /**
  * Configures every MeterRegistry with common tags.
  */
 @Factory
 @RequiresMetrics
-@Requires(property = MICRONAUT_METRICS_COMMON_TAGS)
+@Requires(condition = CommonTagsCondition.class)
 public class CommonTagsConfigurer implements MeterRegistryConfigurer<MeterRegistry> {
 
     private final List<Tag> commonTags = new ArrayList<>();
 
-    public CommonTagsConfigurer(ExportConfigurationProperties configuration) {
-        Properties tags = configuration.getTags();
-        for (String key : tags.stringPropertyNames()) {
-            commonTags.add(Tag.of(key, tags.getProperty(key)));
+    public CommonTagsConfigurer(Environment environment) {
+        Map<String, Object> tags = new TreeMap<>();
+        tags.putAll(readConfiguredTags(environment, MICRONAUT_METRICS_TAGS));
+        tags.putAll(readConfiguredTags(environment, MICRONAUT_METRICS_COMMON_TAGS));
+        for (Map.Entry<String, Object> entry : tags.entrySet()) {
+            commonTags.add(Tag.of(entry.getKey(), String.valueOf(entry.getValue())));
         }
     }
 
@@ -59,5 +65,17 @@ public class CommonTagsConfigurer implements MeterRegistryConfigurer<MeterRegist
     @Override
     public int getOrder() {
         return HIGHEST_PRECEDENCE;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Map<String, Object> readConfiguredTags(Environment environment, String property) {
+        Map<String, Object> configuredTags = new LinkedHashMap<>();
+        if (environment.containsProperty(property)) {
+            configuredTags.putAll(environment.getProperty(property, Map.class).orElse(Map.of()));
+        }
+        if (environment.containsProperties(property)) {
+            configuredTags.putAll(environment.getProperties(property, StringConvention.RAW));
+        }
+        return configuredTags;
     }
 }

--- a/micrometer-core/src/main/java/io/micronaut/configuration/metrics/common/tags/CommonTagsConfigurer.java
+++ b/micrometer-core/src/main/java/io/micronaut/configuration/metrics/common/tags/CommonTagsConfigurer.java
@@ -23,6 +23,7 @@ import io.micronaut.context.annotation.Factory;
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.context.env.Environment;
 import io.micronaut.core.naming.conventions.StringConvention;
+import io.micronaut.core.type.Argument;
 
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -40,6 +41,8 @@ import static io.micronaut.configuration.metrics.micrometer.MeterRegistryFactory
 @RequiresMetrics
 @Requires(condition = CommonTagsCondition.class)
 public class CommonTagsConfigurer implements MeterRegistryConfigurer<MeterRegistry> {
+
+    private static final Argument<Map<String, Object>> TAGS_ARGUMENT = Argument.mapOf(String.class, Object.class);
 
     private final List<Tag> commonTags = new ArrayList<>();
 
@@ -67,15 +70,13 @@ public class CommonTagsConfigurer implements MeterRegistryConfigurer<MeterRegist
         return HIGHEST_PRECEDENCE;
     }
 
-    @SuppressWarnings("unchecked")
     private static Map<String, Object> readConfiguredTags(Environment environment, String property) {
-        Map<String, Object> configuredTags = new LinkedHashMap<>();
-        if (environment.containsProperty(property)) {
-            configuredTags.putAll(environment.getProperty(property, Map.class).orElse(Map.of()));
-        }
         if (environment.containsProperties(property)) {
-            configuredTags.putAll(environment.getProperties(property, StringConvention.RAW));
+            return new LinkedHashMap<>(environment.getProperties(property, StringConvention.RAW));
         }
-        return configuredTags;
+        if (environment.containsProperty(property)) {
+            return new LinkedHashMap<>(environment.getProperty(property, TAGS_ARGUMENT).orElse(Map.of()));
+        }
+        return new LinkedHashMap<>();
     }
 }

--- a/micrometer-core/src/main/java/io/micronaut/configuration/metrics/micrometer/MeterRegistryFactory.java
+++ b/micrometer-core/src/main/java/io/micronaut/configuration/metrics/micrometer/MeterRegistryFactory.java
@@ -45,7 +45,8 @@ public class MeterRegistryFactory {
 
     public static final String MICRONAUT_METRICS = "micronaut.metrics.";
     public static final String MICRONAUT_METRICS_BINDERS = MICRONAUT_METRICS + "binders";
-    public static final String MICRONAUT_METRICS_COMMON_TAGS = MICRONAUT_METRICS + "tags";
+    public static final String MICRONAUT_METRICS_TAGS = MICRONAUT_METRICS + "tags";
+    public static final String MICRONAUT_METRICS_COMMON_TAGS = MICRONAUT_METRICS + "common-tags";
     public static final String MICRONAUT_METRICS_ENABLED = MICRONAUT_METRICS + "enabled";
     public static final String MICRONAUT_METRICS_EXPORT = MICRONAUT_METRICS + "export";
 

--- a/micrometer-core/src/test/groovy/io/micronaut/configuration/metrics/management/endpoint/MetricsEndpointSpec.groovy
+++ b/micrometer-core/src/test/groovy/io/micronaut/configuration/metrics/management/endpoint/MetricsEndpointSpec.groovy
@@ -378,12 +378,13 @@ class MetricsEndpointSpec extends Specification {
     }
 
     @Unroll
-    void "test metrics endpoint with common tags"() {
+    void "test metrics endpoint with common tags from #propertyName"() {
         given:
         run('endpoints.metrics.sensitive'          : false,
             (MICRONAUT_METRICS_ENABLED)            : true,
             "micronaut.metrics.binders.web.enabled": true,
-            "micronaut.metrics.tags"               : ["test1": "test1-val", "test2": "test2-val"])
+            (propertyName + ".test1")             : "test1-val",
+            (propertyName + ".test2")             : "test2-val")
 
         expect:
         100.times {
@@ -400,6 +401,7 @@ class MetricsEndpointSpec extends Specification {
         }
 
         where:
+        propertyName << ["micronaut.metrics.tags", "micronaut.metrics.common-tags"]
         name << ["process.files.open", "process.files.max"]
     }
 

--- a/micrometer-core/src/test/groovy/io/micronaut/configuration/metrics/management/endpoint/MetricsEndpointSpec.groovy
+++ b/micrometer-core/src/test/groovy/io/micronaut/configuration/metrics/management/endpoint/MetricsEndpointSpec.groovy
@@ -378,13 +378,13 @@ class MetricsEndpointSpec extends Specification {
     }
 
     @Unroll
-    void "test metrics endpoint with common tags from #propertyName"() {
+    void "test metrics endpoint with common tags from #configStyle"() {
         given:
-        run('endpoints.metrics.sensitive'          : false,
+        run([
+            'endpoints.metrics.sensitive'          : false,
             (MICRONAUT_METRICS_ENABLED)            : true,
-            "micronaut.metrics.binders.web.enabled": true,
-            (propertyName + ".test1")             : "test1-val",
-            (propertyName + ".test2")             : "test2-val")
+            "micronaut.metrics.binders.web.enabled": true
+        ] + tagConfig)
 
         expect:
         100.times {
@@ -401,8 +401,11 @@ class MetricsEndpointSpec extends Specification {
         }
 
         where:
-        propertyName << ["micronaut.metrics.tags", "micronaut.metrics.common-tags"]
-        name << ["process.files.open", "process.files.max"]
+        configStyle         | name                | tagConfig
+        "legacy dotted"     | "process.files.open" | ["micronaut.metrics.tags.test1": "test1-val", "micronaut.metrics.tags.test2": "test2-val"]
+        "legacy map"        | "process.files.max"  | ["micronaut.metrics.tags": [test1: "test1-val", test2: "test2-val"]]
+        "common-tags dotted" | "process.files.open" | ["micronaut.metrics.common-tags.test1": "test1-val", "micronaut.metrics.common-tags.test2": "test2-val"]
+        "common-tags map"    | "process.files.max"  | ["micronaut.metrics.common-tags": [test1: "test1-val", test2: "test2-val"]]
     }
 
     @Unroll

--- a/micrometer-core/src/test/groovy/io/micronaut/configuration/metrics/micrometer/MeterRegistryConfigurerOrderSpec.groovy
+++ b/micrometer-core/src/test/groovy/io/micronaut/configuration/metrics/micrometer/MeterRegistryConfigurerOrderSpec.groovy
@@ -11,14 +11,13 @@ class MeterRegistryConfigurerOrderSpec extends Specification {
     void "verify beans created by in correct order"() {
         when:
         ApplicationContext ctx = ApplicationContext.run([
-                "test.properties.enabled": true,
-                "micronaut.metrics.tags.test": "test"
+                "test.properties.enabled": true
         ])
 
         List<MeterRegistryConfigurer> configurerList = ctx.getBeansOfType(MeterRegistryConfigurer)
 
         then:
-        configurerList.size() == 3
+        configurerList.size() == 2
         configurerList.last().getClass() == CompositeMeterRegistryConfigurer.class
 
         cleanup:

--- a/micrometer-registry-prometheus/src/test/groovy/io/micronaut/configuration/metrics/micrometer/prometheus/PrometheusMeterRegistryFactorySpec.groovy
+++ b/micrometer-registry-prometheus/src/test/groovy/io/micronaut/configuration/metrics/micrometer/prometheus/PrometheusMeterRegistryFactorySpec.groovy
@@ -3,7 +3,10 @@ package io.micronaut.configuration.metrics.micrometer.prometheus
 import io.micrometer.core.instrument.MeterRegistry
 import io.micrometer.core.instrument.composite.CompositeMeterRegistry
 import io.micrometer.prometheusmetrics.PrometheusMeterRegistry
+import io.micronaut.configuration.metrics.aggregator.MeterRegistryConfigurer
 import io.micronaut.context.ApplicationContext
+import io.micronaut.context.annotation.Requires
+import jakarta.inject.Singleton
 import spock.lang.Specification
 import spock.lang.Unroll
 
@@ -100,5 +103,39 @@ class PrometheusMeterRegistryFactorySpec extends Specification {
 
         cleanup:
         context.stop()
+    }
+
+    void "verify common tags are applied before meters are registered"() {
+        given:
+        ApplicationContext context = ApplicationContext.run([
+                "spec.name": getClass().getSimpleName()
+        ])
+        PrometheusMeterRegistry prometheusMeterRegistry = context.getBean(PrometheusMeterRegistry)
+
+        when:
+        prometheusMeterRegistry.counter("test.counter").increment()
+        context.getBean(CompositeMeterRegistry).counter("test.counter").increment()
+
+        then:
+        noExceptionThrown()
+        prometheusMeterRegistry.scrape().contains('application="test-suite"')
+
+        cleanup:
+        context.stop()
+    }
+
+    @Singleton
+    @Requires(property = "spec.name", value = "PrometheusMeterRegistryFactorySpec")
+    static class CustomCommonTagsConfigurer implements MeterRegistryConfigurer<MeterRegistry> {
+
+        @Override
+        void configure(MeterRegistry meterRegistry) {
+            meterRegistry.config().commonTags("application", "test-suite")
+        }
+
+        @Override
+        Class<MeterRegistry> getType() {
+            return MeterRegistry
+        }
     }
 }

--- a/src/main/docs/guide/metricsConcepts.adoc
+++ b/src/main/docs/guide/metricsConcepts.adoc
@@ -26,6 +26,17 @@ include::{metricscore}/aggregator/MeterRegistryConfigurer.java[]
 include::{testsmetricscore}/SimpleMeterRegistryConfigurer.java[]
 ----
 
+Micronaut can also add common tags to every meter via configuration. The legacy `micronaut.metrics.tags.*` prefix remains supported, and `micronaut.metrics.common-tags.*` is available as a clearer alias.
+
+[configuration]
+----
+micronaut:
+  metrics:
+    common-tags:
+      application: ${micronaut.application.name}
+      region: us-east-1
+----
+
 === Meter Filter
 
 * A https://micrometer.io/docs/concepts#_meter_filters[meter filter] can be used to determine if a Meter is to be added to the registry.


### PR DESCRIPTION
## Summary
- add regression coverage for Prometheus common tags applied before meters are registered
- support both `micronaut.metrics.tags.*` and `micronaut.metrics.common-tags.*` when building common tags
- document `micronaut.metrics.common-tags.*` as the clearer alias while keeping the legacy prefix working

## Verification
- `./gradlew :micronaut-micrometer-core:test --rerun-tasks --tests 'io.micronaut.configuration.metrics.management.endpoint.MetricsEndpointSpec' --tests 'io.micronaut.configuration.metrics.micrometer.MeterRegistryConfigurerOrderSpec'`
- `./gradlew :micronaut-micrometer-registry-prometheus:test --tests 'io.micronaut.configuration.metrics.micrometer.prometheus.PrometheusMeterRegistryFactorySpec'`


Resolves #114
