### PR TITLE
Set TimedInterceptor order to trace phase

### DIFF
--- a/micrometer-core/src/main/java/io/micronaut/configuration/metrics/micrometer/intercept/TimedInterceptor.java
+++ b/micrometer-core/src/main/java/io/micronaut/configuration/metrics/micrometer/intercept/TimedInterceptor.java
@@ -21,6 +21,7 @@ import io.micrometer.core.aop.TimedAspect;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer;
 import io.micronaut.aop.InterceptedMethod;
+import io.micronaut.aop.InterceptPhase;
 import io.micronaut.aop.InterceptorBean;
 import io.micronaut.aop.MethodInterceptor;
 import io.micronaut.aop.MethodInvocationContext;
@@ -96,6 +97,11 @@ public class TimedInterceptor implements MethodInterceptor<Object, Object> {
         this.meterRegistry = meterRegistry;
         this.conversionService = conversionService;
         this.methodTaggers = Objects.requireNonNullElse(methodTaggers, Collections.emptyList());
+    }
+
+    @Override
+    public int getOrder() {
+        return InterceptPhase.TRACE.getPosition();
     }
 
     @Override

--- a/micrometer-core/src/test/groovy/io/micronaut/configuration/metrics/annotation/TimeAnnotationSpec.groovy
+++ b/micrometer-core/src/test/groovy/io/micronaut/configuration/metrics/annotation/TimeAnnotationSpec.groovy
@@ -3,7 +3,9 @@ package io.micronaut.configuration.metrics.annotation
 import io.micrometer.core.instrument.MeterRegistry
 import io.micrometer.core.instrument.Tag
 import io.micrometer.core.instrument.search.MeterNotFoundException
+import io.micronaut.aop.InterceptPhase
 import io.micronaut.context.ApplicationContext
+import io.micronaut.configuration.metrics.micrometer.intercept.TimedInterceptor
 import spock.lang.Specification
 import spock.util.concurrent.PollingConditions
 
@@ -12,6 +14,17 @@ import java.util.function.Consumer
 import static java.util.concurrent.TimeUnit.MILLISECONDS
 
 class TimeAnnotationSpec extends Specification {
+
+    void "timed interceptor runs in trace phase"() {
+        given:
+        ApplicationContext ctx = ApplicationContext.run()
+
+        expect:
+        ctx.getBean(TimedInterceptor).order == InterceptPhase.TRACE.position
+
+        cleanup:
+        ctx.close()
+    }
 
     void "test timed annotation usage"() {
         given:


### PR DESCRIPTION
## Summary
- Set TimedInterceptor order to the trace intercept phase.
- Add a regression spec that verifies the interceptor order.

## Testing
- ./gradlew :micronaut-micrometer-core:test --tests io.micronaut.configuration.metrics.annotation.TimeAnnotationSpec

Resolves #549
