### PR TITLE
Add HTTP client pool metrics

### DIFF
--- a/micrometer-core/build.gradle.kts
+++ b/micrometer-core/build.gradle.kts
@@ -10,6 +10,7 @@ dependencies {
     compileOnly(libs.grpc.api)
     compileOnly(mnLogging.logback.classic)
     compileOnly(mnCache.micronaut.cache.core)
+    compileOnly(mn.micronaut.http.client)
     compileOnly(mn.micronaut.http.server.netty)
     compileOnly(mnSql.micronaut.jdbc)
     compileOnly(mn.micronaut.management)

--- a/micrometer-core/src/main/java/io/micronaut/http/client/netty/HttpClientPoolMetricsClientBinder.java
+++ b/micrometer-core/src/main/java/io/micronaut/http/client/netty/HttpClientPoolMetricsClientBinder.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.http.client.netty;
+
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.Tags;
+import io.micrometer.core.instrument.binder.BaseUnits;
+import io.micronaut.configuration.metrics.annotation.RequiresMetrics;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.context.event.BeanCreatedEvent;
+import io.micronaut.context.event.BeanCreatedEventListener;
+import io.micronaut.core.annotation.Internal;
+import jakarta.inject.Singleton;
+
+import static io.micronaut.configuration.metrics.micrometer.MeterRegistryFactory.MICRONAUT_METRICS_BINDERS;
+import static io.micronaut.http.client.netty.HttpClientPoolMetricsRecorder.CLIENT_TAG;
+import static io.micronaut.http.client.netty.HttpClientPoolMetricsRecorder.CONNECTIONS;
+import static io.micronaut.http.client.netty.HttpClientPoolMetricsRecorder.REQUESTS;
+import static io.micronaut.http.client.netty.HttpClientPoolMetricsRecorder.STATE_ACTIVE;
+import static io.micronaut.http.client.netty.HttpClientPoolMetricsRecorder.STATE_OPEN;
+import static io.micronaut.http.client.netty.HttpClientPoolMetricsRecorder.STATE_TAG;
+
+/**
+ * Adds per-client gauges for default Netty HTTP client pool state.
+ */
+@Singleton
+@Internal
+@RequiresMetrics
+@Requires(classes = DefaultHttpClient.class)
+@Requires(property = MICRONAUT_METRICS_BINDERS + ".web.client.pool.enabled", value = "true")
+final class HttpClientPoolMetricsClientBinder implements BeanCreatedEventListener<DefaultHttpClient> {
+    private final HttpClientPoolMetricsRecorder recorder;
+
+    HttpClientPoolMetricsClientBinder(HttpClientPoolMetricsRecorder recorder) {
+        this.recorder = recorder;
+    }
+
+    @Override
+    public DefaultHttpClient onCreated(BeanCreatedEvent<DefaultHttpClient> event) {
+        DefaultHttpClient client = event.getBean();
+        String clientName = event.getBeanIdentifier().getName();
+        Tags openTags = Tags.of(CLIENT_TAG, clientName, STATE_TAG, STATE_OPEN);
+        Tags activeTags = Tags.of(CLIENT_TAG, clientName, STATE_TAG, STATE_ACTIVE);
+        Gauge.builder(CONNECTIONS, client, c -> c.connectionManager().getChannels().size())
+            .tags(openTags)
+            .baseUnit(BaseUnits.CONNECTIONS)
+            .description("The number of HTTP client pool connections currently open for this client.")
+            .register(recorder.meterRegistry());
+        Gauge.builder(REQUESTS, client, c -> c.connectionManager().liveRequestCount())
+            .tags(activeTags)
+            .description("The number of HTTP client requests currently checked out from the pool for this client.")
+            .register(recorder.meterRegistry());
+        return client;
+    }
+}

--- a/micrometer-core/src/main/java/io/micronaut/http/client/netty/HttpClientPoolMetricsClientBinder.java
+++ b/micrometer-core/src/main/java/io/micronaut/http/client/netty/HttpClientPoolMetricsClientBinder.java
@@ -26,6 +26,7 @@ import io.micronaut.core.annotation.Internal;
 import jakarta.inject.Singleton;
 
 import static io.micronaut.configuration.metrics.micrometer.MeterRegistryFactory.MICRONAUT_METRICS_BINDERS;
+import static io.micronaut.core.util.StringUtils.FALSE;
 import static io.micronaut.http.client.netty.HttpClientPoolMetricsRecorder.CLIENT_TAG;
 import static io.micronaut.http.client.netty.HttpClientPoolMetricsRecorder.CONNECTIONS;
 import static io.micronaut.http.client.netty.HttpClientPoolMetricsRecorder.REQUESTS;
@@ -40,7 +41,7 @@ import static io.micronaut.http.client.netty.HttpClientPoolMetricsRecorder.STATE
 @Internal
 @RequiresMetrics
 @Requires(classes = DefaultHttpClient.class)
-@Requires(property = MICRONAUT_METRICS_BINDERS + ".web.client.pool.enabled", value = "true")
+@Requires(property = MICRONAUT_METRICS_BINDERS + ".web.client.pool.enabled", defaultValue = FALSE, notEquals = FALSE)
 final class HttpClientPoolMetricsClientBinder implements BeanCreatedEventListener<DefaultHttpClient> {
     private final HttpClientPoolMetricsRecorder recorder;
 

--- a/micrometer-core/src/main/java/io/micronaut/http/client/netty/HttpClientPoolMetricsCustomizerBinder.java
+++ b/micrometer-core/src/main/java/io/micronaut/http/client/netty/HttpClientPoolMetricsCustomizerBinder.java
@@ -20,7 +20,6 @@ import io.micronaut.context.annotation.Requires;
 import io.micronaut.context.event.BeanCreatedEvent;
 import io.micronaut.context.event.BeanCreatedEventListener;
 import io.micronaut.core.annotation.Internal;
-import io.netty.bootstrap.Bootstrap;
 import io.netty.channel.Channel;
 import jakarta.inject.Singleton;
 import org.jspecify.annotations.Nullable;
@@ -50,30 +49,36 @@ final class HttpClientPoolMetricsCustomizerBinder implements BeanCreatedEventLis
         return registry;
     }
 
-    private record MetricsCustomizer(
-        HttpClientPoolMetricsRecorder recorder,
-        @Nullable Channel channel,
-        HttpClientPoolMetricsRecorder.@Nullable ConnectionAttempt attempt
-    ) implements NettyClientCustomizer {
+    private static final class MetricsCustomizer implements NettyClientCustomizer {
+        private final HttpClientPoolMetricsRecorder recorder;
+        private final @Nullable Channel channel;
+        private HttpClientPoolMetricsRecorder.@Nullable ConnectionAttempt attempt;
 
-        @Override
-        public NettyClientCustomizer specializeForBootstrap(Bootstrap bootstrap) {
-            return new MetricsCustomizer(recorder, null, recorder.beginConnectionAttempt());
+        private MetricsCustomizer(
+            HttpClientPoolMetricsRecorder recorder,
+            @Nullable Channel channel,
+            HttpClientPoolMetricsRecorder.@Nullable ConnectionAttempt attempt
+        ) {
+            this.recorder = recorder;
+            this.channel = channel;
+            this.attempt = attempt;
         }
 
         @Override
         public NettyClientCustomizer specializeForChannel(Channel channel, ChannelRole role) {
-            if (role == ChannelRole.CONNECTION && attempt != null) {
-                channel.closeFuture().addListener(future -> recorder.connectionClosed(attempt));
-                return new MetricsCustomizer(recorder, channel, attempt);
+            if (role == ChannelRole.CONNECTION) {
+                return new MetricsCustomizer(recorder, channel, null);
             }
             return this;
         }
 
         @Override
         public void onStreamPipelineBuilt() {
-            if (channel != null && attempt != null) {
-                recorder.connectionEstablished(attempt);
+            if (channel != null && attempt == null) {
+                HttpClientPoolMetricsRecorder.ConnectionAttempt newAttempt = recorder.beginConnectionAttempt();
+                attempt = newAttempt;
+                channel.closeFuture().addListener(future -> recorder.connectionClosed(newAttempt));
+                recorder.connectionEstablished(newAttempt);
             }
         }
     }

--- a/micrometer-core/src/main/java/io/micronaut/http/client/netty/HttpClientPoolMetricsCustomizerBinder.java
+++ b/micrometer-core/src/main/java/io/micronaut/http/client/netty/HttpClientPoolMetricsCustomizerBinder.java
@@ -23,8 +23,10 @@ import io.micronaut.core.annotation.Internal;
 import io.netty.bootstrap.Bootstrap;
 import io.netty.channel.Channel;
 import jakarta.inject.Singleton;
+import org.jspecify.annotations.Nullable;
 
 import static io.micronaut.configuration.metrics.micrometer.MeterRegistryFactory.MICRONAUT_METRICS_BINDERS;
+import static io.micronaut.core.util.StringUtils.FALSE;
 
 /**
  * Registers HTTP client pool connection lifecycle instrumentation.
@@ -33,7 +35,7 @@ import static io.micronaut.configuration.metrics.micrometer.MeterRegistryFactory
 @Internal
 @RequiresMetrics
 @Requires(classes = NettyClientCustomizer.Registry.class)
-@Requires(property = MICRONAUT_METRICS_BINDERS + ".web.client.pool.enabled", value = "true")
+@Requires(property = MICRONAUT_METRICS_BINDERS + ".web.client.pool.enabled", defaultValue = FALSE, notEquals = FALSE)
 final class HttpClientPoolMetricsCustomizerBinder implements BeanCreatedEventListener<NettyClientCustomizer.Registry> {
     private final HttpClientPoolMetricsRecorder recorder;
 
@@ -50,8 +52,8 @@ final class HttpClientPoolMetricsCustomizerBinder implements BeanCreatedEventLis
 
     private record MetricsCustomizer(
         HttpClientPoolMetricsRecorder recorder,
-        Channel channel,
-        HttpClientPoolMetricsRecorder.ConnectionAttempt attempt
+        @Nullable Channel channel,
+        HttpClientPoolMetricsRecorder.@Nullable ConnectionAttempt attempt
     ) implements NettyClientCustomizer {
 
         @Override

--- a/micrometer-core/src/main/java/io/micronaut/http/client/netty/HttpClientPoolMetricsCustomizerBinder.java
+++ b/micrometer-core/src/main/java/io/micronaut/http/client/netty/HttpClientPoolMetricsCustomizerBinder.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.http.client.netty;
+
+import io.micronaut.configuration.metrics.annotation.RequiresMetrics;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.context.event.BeanCreatedEvent;
+import io.micronaut.context.event.BeanCreatedEventListener;
+import io.micronaut.core.annotation.Internal;
+import io.netty.bootstrap.Bootstrap;
+import io.netty.channel.Channel;
+import jakarta.inject.Singleton;
+
+import static io.micronaut.configuration.metrics.micrometer.MeterRegistryFactory.MICRONAUT_METRICS_BINDERS;
+
+/**
+ * Registers HTTP client pool connection lifecycle instrumentation.
+ */
+@Singleton
+@Internal
+@RequiresMetrics
+@Requires(classes = NettyClientCustomizer.Registry.class)
+@Requires(property = MICRONAUT_METRICS_BINDERS + ".web.client.pool.enabled", value = "true")
+final class HttpClientPoolMetricsCustomizerBinder implements BeanCreatedEventListener<NettyClientCustomizer.Registry> {
+    private final HttpClientPoolMetricsRecorder recorder;
+
+    HttpClientPoolMetricsCustomizerBinder(HttpClientPoolMetricsRecorder recorder) {
+        this.recorder = recorder;
+    }
+
+    @Override
+    public NettyClientCustomizer.Registry onCreated(BeanCreatedEvent<NettyClientCustomizer.Registry> event) {
+        NettyClientCustomizer.Registry registry = event.getBean();
+        registry.register(new MetricsCustomizer(recorder, null, null));
+        return registry;
+    }
+
+    private record MetricsCustomizer(
+        HttpClientPoolMetricsRecorder recorder,
+        Channel channel,
+        HttpClientPoolMetricsRecorder.ConnectionAttempt attempt
+    ) implements NettyClientCustomizer {
+
+        @Override
+        public NettyClientCustomizer specializeForBootstrap(Bootstrap bootstrap) {
+            return new MetricsCustomizer(recorder, null, recorder.beginConnectionAttempt());
+        }
+
+        @Override
+        public NettyClientCustomizer specializeForChannel(Channel channel, ChannelRole role) {
+            if (role == ChannelRole.CONNECTION && attempt != null) {
+                channel.closeFuture().addListener(future -> recorder.connectionClosed(attempt));
+                return new MetricsCustomizer(recorder, channel, attempt);
+            }
+            return this;
+        }
+
+        @Override
+        public void onStreamPipelineBuilt() {
+            if (channel != null && attempt != null) {
+                recorder.connectionEstablished(attempt);
+            }
+        }
+    }
+}

--- a/micrometer-core/src/main/java/io/micronaut/http/client/netty/HttpClientPoolMetricsRecorder.java
+++ b/micrometer-core/src/main/java/io/micronaut/http/client/netty/HttpClientPoolMetricsRecorder.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.http.client.netty;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tags;
+import io.micrometer.core.instrument.Timer;
+import io.micrometer.core.instrument.binder.BaseUnits;
+import io.micronaut.core.annotation.Internal;
+import jakarta.inject.Singleton;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Records HTTP client pool metrics.
+ */
+@Singleton
+@Internal
+final class HttpClientPoolMetricsRecorder {
+    static final String CONNECTIONS = "http.client.pool.connections";
+    static final String REQUESTS = "http.client.pool.requests";
+    static final String CONNECTIONS_CREATED = "http.client.pool.connections.created";
+    static final String CONNECTIONS_CREATE_TIME = "http.client.pool.connections.create.time";
+    static final String CLIENT_TAG = "client";
+    static final String STATE_TAG = "state";
+    static final String CLIENT_ALL = "all";
+    static final String STATE_OPEN = "open";
+    static final String STATE_PENDING = "pending";
+    static final String STATE_ACTIVE = "active";
+
+    private final MeterRegistry meterRegistry;
+    private final AtomicInteger activeConnectionCount = new AtomicInteger();
+    private final AtomicInteger pendingConnectionCount = new AtomicInteger();
+    private final Counter createdConnectionCount;
+    private final Timer connectionCreateTimer;
+
+    HttpClientPoolMetricsRecorder(MeterRegistry meterRegistry) {
+        this.meterRegistry = meterRegistry;
+        Tags openTags = Tags.of(CLIENT_TAG, CLIENT_ALL, STATE_TAG, STATE_OPEN);
+        Tags pendingTags = Tags.of(CLIENT_TAG, CLIENT_ALL, STATE_TAG, STATE_PENDING);
+        Gauge.builder(CONNECTIONS, activeConnectionCount, AtomicInteger::get)
+            .tags(openTags)
+            .baseUnit(BaseUnits.CONNECTIONS)
+            .description("The number of HTTP client pool connections currently open.")
+            .register(meterRegistry);
+        Gauge.builder(CONNECTIONS, pendingConnectionCount, AtomicInteger::get)
+            .tags(pendingTags)
+            .baseUnit(BaseUnits.CONNECTIONS)
+            .description("The number of HTTP client pool connections currently being established.")
+            .register(meterRegistry);
+        createdConnectionCount = Counter.builder(CONNECTIONS_CREATED)
+            .tag(CLIENT_TAG, CLIENT_ALL)
+            .baseUnit(BaseUnits.CONNECTIONS)
+            .description("The number of HTTP client pool connections created.")
+            .register(meterRegistry);
+        connectionCreateTimer = Timer.builder(CONNECTIONS_CREATE_TIME)
+            .tag(CLIENT_TAG, CLIENT_ALL)
+            .description("The time taken to create HTTP client pool connections.")
+            .register(meterRegistry);
+    }
+
+    ConnectionAttempt beginConnectionAttempt() {
+        pendingConnectionCount.incrementAndGet();
+        return new ConnectionAttempt(Timer.start(meterRegistry));
+    }
+
+    void connectionEstablished(ConnectionAttempt attempt) {
+        if (attempt.pending.compareAndSet(true, false)) {
+            pendingConnectionCount.decrementAndGet();
+            activeConnectionCount.incrementAndGet();
+            attempt.active.set(true);
+            createdConnectionCount.increment();
+            attempt.sample.stop(connectionCreateTimer);
+        }
+    }
+
+    void connectionClosed(ConnectionAttempt attempt) {
+        if (attempt.pending.compareAndSet(true, false)) {
+            pendingConnectionCount.decrementAndGet();
+        }
+        if (attempt.active.compareAndSet(true, false)) {
+            activeConnectionCount.decrementAndGet();
+        }
+    }
+
+    MeterRegistry meterRegistry() {
+        return meterRegistry;
+    }
+
+    static final class ConnectionAttempt {
+        private final Timer.Sample sample;
+        private final AtomicBoolean pending = new AtomicBoolean(true);
+        private final AtomicBoolean active = new AtomicBoolean(false);
+
+        private ConnectionAttempt(Timer.Sample sample) {
+            this.sample = sample;
+        }
+    }
+}

--- a/micrometer-core/src/main/java/io/micronaut/http/client/netty/HttpClientPoolMetricsRecorder.java
+++ b/micrometer-core/src/main/java/io/micronaut/http/client/netty/HttpClientPoolMetricsRecorder.java
@@ -45,7 +45,7 @@ final class HttpClientPoolMetricsRecorder {
     static final String STATE_ACTIVE = "active";
 
     private final MeterRegistry meterRegistry;
-    private final AtomicInteger activeConnectionCount = new AtomicInteger();
+    private final AtomicInteger openConnectionCount = new AtomicInteger();
     private final AtomicInteger pendingConnectionCount = new AtomicInteger();
     private final Counter createdConnectionCount;
     private final Timer connectionCreateTimer;
@@ -54,7 +54,7 @@ final class HttpClientPoolMetricsRecorder {
         this.meterRegistry = meterRegistry;
         Tags openTags = Tags.of(CLIENT_TAG, CLIENT_ALL, STATE_TAG, STATE_OPEN);
         Tags pendingTags = Tags.of(CLIENT_TAG, CLIENT_ALL, STATE_TAG, STATE_PENDING);
-        Gauge.builder(CONNECTIONS, activeConnectionCount, AtomicInteger::get)
+        Gauge.builder(CONNECTIONS, openConnectionCount, AtomicInteger::get)
             .tags(openTags)
             .baseUnit(BaseUnits.CONNECTIONS)
             .description("The number of HTTP client pool connections currently open.")
@@ -83,8 +83,8 @@ final class HttpClientPoolMetricsRecorder {
     void connectionEstablished(ConnectionAttempt attempt) {
         if (attempt.pending.compareAndSet(true, false)) {
             pendingConnectionCount.decrementAndGet();
-            activeConnectionCount.incrementAndGet();
-            attempt.active.set(true);
+            openConnectionCount.incrementAndGet();
+            attempt.open.set(true);
             createdConnectionCount.increment();
             attempt.sample.stop(connectionCreateTimer);
         }
@@ -94,8 +94,8 @@ final class HttpClientPoolMetricsRecorder {
         if (attempt.pending.compareAndSet(true, false)) {
             pendingConnectionCount.decrementAndGet();
         }
-        if (attempt.active.compareAndSet(true, false)) {
-            activeConnectionCount.decrementAndGet();
+        if (attempt.open.compareAndSet(true, false)) {
+            openConnectionCount.decrementAndGet();
         }
     }
 
@@ -106,7 +106,7 @@ final class HttpClientPoolMetricsRecorder {
     static final class ConnectionAttempt {
         private final Timer.Sample sample;
         private final AtomicBoolean pending = new AtomicBoolean(true);
-        private final AtomicBoolean active = new AtomicBoolean(false);
+        private final AtomicBoolean open = new AtomicBoolean(false);
 
         private ConnectionAttempt(Timer.Sample sample) {
             this.sample = sample;

--- a/micrometer-core/src/test/groovy/io/micronaut/http/client/netty/HttpClientPoolMetricsSpec.groovy
+++ b/micrometer-core/src/test/groovy/io/micronaut/http/client/netty/HttpClientPoolMetricsSpec.groovy
@@ -17,6 +17,8 @@ import static io.micronaut.http.client.netty.HttpClientPoolMetricsRecorder.CLIEN
 import static io.micronaut.http.client.netty.HttpClientPoolMetricsRecorder.CONNECTIONS
 import static io.micronaut.http.client.netty.HttpClientPoolMetricsRecorder.CONNECTIONS_CREATED
 import static io.micronaut.http.client.netty.HttpClientPoolMetricsRecorder.CONNECTIONS_CREATE_TIME
+import static io.micronaut.http.client.netty.HttpClientPoolMetricsRecorder.REQUESTS
+import static io.micronaut.http.client.netty.HttpClientPoolMetricsRecorder.STATE_ACTIVE
 import static io.micronaut.http.client.netty.HttpClientPoolMetricsRecorder.STATE_OPEN
 import static io.micronaut.http.client.netty.HttpClientPoolMetricsRecorder.STATE_PENDING
 import static io.micronaut.http.client.netty.HttpClientPoolMetricsRecorder.STATE_TAG
@@ -40,6 +42,7 @@ class HttpClientPoolMetricsSpec extends Specification {
         MICRONAUT_METRICS_ENABLED                                  | true    | false
         MICRONAUT_METRICS_ENABLED                                  | false   | false
         MICRONAUT_METRICS_BINDERS + ".web.client.pool.enabled"     | true    | true
+        MICRONAUT_METRICS_BINDERS + ".web.client.pool.enabled"     | "yes"   | true
         MICRONAUT_METRICS_BINDERS + ".web.client.pool.enabled"     | false   | false
     }
 
@@ -51,6 +54,7 @@ class HttpClientPoolMetricsSpec extends Specification {
         ])
         MeterRegistry registry = embeddedServer.applicationContext.getBean(MeterRegistry)
         DummyClient client = embeddedServer.applicationContext.getBean(DummyClient)
+        embeddedServer.applicationContext.getBean(DefaultHttpClient)
 
         then:
         client.root() == "root"
@@ -60,6 +64,7 @@ class HttpClientPoolMetricsSpec extends Specification {
         registry.get(CONNECTIONS_CREATE_TIME).tag(CLIENT_TAG, CLIENT_ALL).timer().count() >= 1
         registry.get(CONNECTIONS).tags(CLIENT_TAG, CLIENT_ALL, STATE_TAG, STATE_OPEN).gauge().value() >= 1
         registry.get(CONNECTIONS).tags(CLIENT_TAG, CLIENT_ALL, STATE_TAG, STATE_PENDING).gauge().value() == 0
+        registry.get(REQUESTS).tags(CLIENT_TAG, "Primary", STATE_TAG, STATE_ACTIVE).gauge().value() == 0
 
         cleanup:
         embeddedServer.close()

--- a/micrometer-core/src/test/groovy/io/micronaut/http/client/netty/HttpClientPoolMetricsSpec.groovy
+++ b/micrometer-core/src/test/groovy/io/micronaut/http/client/netty/HttpClientPoolMetricsSpec.groovy
@@ -3,10 +3,23 @@ package io.micronaut.http.client.netty
 import io.micrometer.core.instrument.MeterRegistry
 import io.micronaut.context.ApplicationContext
 import io.micronaut.context.annotation.Requires
+import io.micronaut.core.util.CollectionUtils
 import io.micronaut.http.annotation.Controller
 import io.micronaut.http.annotation.Get
+import io.micronaut.http.client.HttpVersionSelection
 import io.micronaut.http.client.annotation.Client
+import io.micronaut.http.uri.UriBuilder
 import io.micronaut.runtime.server.EmbeddedServer
+import io.micronaut.websocket.WebSocketBroadcaster
+import io.micronaut.websocket.WebSocketClient
+import io.micronaut.websocket.WebSocketSession
+import io.micronaut.websocket.annotation.ClientWebSocket
+import io.micronaut.websocket.annotation.OnClose
+import io.micronaut.websocket.annotation.OnMessage
+import io.micronaut.websocket.annotation.OnOpen
+import io.micronaut.websocket.annotation.ServerWebSocket
+import org.reactivestreams.Publisher
+import reactor.core.publisher.Flux
 import spock.lang.Specification
 import spock.lang.Unroll
 
@@ -46,14 +59,15 @@ class HttpClientPoolMetricsSpec extends Specification {
         MICRONAUT_METRICS_BINDERS + ".web.client.pool.enabled"     | false   | false
     }
 
-    void "test http client pool metrics meters are present"() {
+    @Unroll
+    void "test http client pool metrics meters are present for #description"() {
         when:
-        EmbeddedServer embeddedServer = ApplicationContext.run(EmbeddedServer, [
+        EmbeddedServer embeddedServer = ApplicationContext.run(EmbeddedServer, properties + [
                 (MICRONAUT_METRICS_BINDERS + ".web.client.pool.enabled"): true,
                 "spec.name": getClass().getSimpleName()
         ])
         MeterRegistry registry = embeddedServer.applicationContext.getBean(MeterRegistry)
-        DummyClient client = embeddedServer.applicationContext.getBean(DummyClient)
+        def client = embeddedServer.applicationContext.getBean(clientType)
         embeddedServer.applicationContext.getBean(DefaultHttpClient)
 
         then:
@@ -68,6 +82,47 @@ class HttpClientPoolMetricsSpec extends Specification {
 
         cleanup:
         embeddedServer.close()
+
+        where:
+        description | clientType       | properties
+        "http/1.1"  | DummyClient      | [:]
+        "http/2"    | Http2DummyClient | [
+                "micronaut.server.http-version"                                : "HTTP_2_0",
+                "micronaut.server.ssl.build-self-signed"                       : true,
+                "micronaut.server.ssl.enabled"                                 : true,
+                "micronaut.server.ssl.port"                                    : 0,
+                "micronaut.http.client.ssl.insecure-trust-all-certificates"    : true
+        ]
+    }
+
+    void "test websocket clients do not register pool connection attempts"() {
+        when:
+        EmbeddedServer embeddedServer = ApplicationContext.run(EmbeddedServer, [
+                (MICRONAUT_METRICS_BINDERS + ".web.client.pool.enabled"): true,
+                "spec.name": getClass().getSimpleName()
+        ])
+        MeterRegistry registry = embeddedServer.applicationContext.getBean(MeterRegistry)
+        WebSocketDummyClient client = createWebSocketClient(embeddedServer.applicationContext, embeddedServer.port, "Travolta")
+
+        then:
+        client != null
+        registry.get(CONNECTIONS_CREATED).tag(CLIENT_TAG, CLIENT_ALL).counter().count() == 0
+        registry.get(CONNECTIONS).tags(CLIENT_TAG, CLIENT_ALL, STATE_TAG, STATE_OPEN).gauge().value() == 0
+        registry.get(CONNECTIONS).tags(CLIENT_TAG, CLIENT_ALL, STATE_TAG, STATE_PENDING).gauge().value() == 0
+
+        cleanup:
+        client?.close()
+        embeddedServer?.close()
+    }
+
+    private static WebSocketDummyClient createWebSocketClient(ApplicationContext context, int port, String username) {
+        WebSocketClient webSocketClient = context.getBean(WebSocketClient)
+        URI uri = UriBuilder.of("ws://localhost")
+                .port(port)
+                .path("pool-metrics-ws")
+                .path("{username}")
+                .expand(CollectionUtils.mapOf("username", username))
+        Flux.from(webSocketClient.connect(WebSocketDummyClient, uri)).blockFirst()
     }
 
     @Requires(property = "spec.name", value = "HttpClientPoolMetricsSpec")
@@ -78,11 +133,51 @@ class HttpClientPoolMetricsSpec extends Specification {
     }
 
     @Requires(property = "spec.name", value = "HttpClientPoolMetricsSpec")
+    @Client(value = "/pool-metrics", alpnModes = HttpVersionSelection.ALPN_HTTP_2)
+    private static interface Http2DummyClient {
+        @Get
+        String root()
+    }
+
+    @Requires(property = "spec.name", value = "HttpClientPoolMetricsSpec")
+    @ClientWebSocket
+    private static abstract class WebSocketDummyClient implements AutoCloseable {
+        @OnMessage
+        void onMessage(String message) {
+        }
+    }
+
+    @Requires(property = "spec.name", value = "HttpClientPoolMetricsSpec")
     @Controller("/pool-metrics")
     private static class DummyController {
         @Get
         String root() {
             "root"
+        }
+    }
+
+    @Requires(property = "spec.name", value = "HttpClientPoolMetricsSpec")
+    @ServerWebSocket("/pool-metrics-ws/{username}")
+    private static class DummyWebSocket {
+        private final WebSocketBroadcaster broadcaster
+
+        DummyWebSocket(WebSocketBroadcaster broadcaster) {
+            this.broadcaster = broadcaster
+        }
+
+        @OnOpen
+        Publisher<String> onOpen(String username, WebSocketSession session) {
+            broadcaster.broadcast("Joined $username")
+        }
+
+        @OnMessage
+        Publisher<String> onMessage(String username, String message, WebSocketSession session) {
+            broadcaster.broadcast("[$username] $message")
+        }
+
+        @OnClose
+        Publisher<String> onClose(String username, WebSocketSession session) {
+            broadcaster.broadcast("Leaving $username")
         }
     }
 }

--- a/micrometer-core/src/test/groovy/io/micronaut/http/client/netty/HttpClientPoolMetricsSpec.groovy
+++ b/micrometer-core/src/test/groovy/io/micronaut/http/client/netty/HttpClientPoolMetricsSpec.groovy
@@ -1,0 +1,83 @@
+package io.micronaut.http.client.netty
+
+import io.micrometer.core.instrument.MeterRegistry
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.annotation.Requires
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Get
+import io.micronaut.http.client.annotation.Client
+import io.micronaut.runtime.server.EmbeddedServer
+import spock.lang.Specification
+import spock.lang.Unroll
+
+import static io.micronaut.configuration.metrics.micrometer.MeterRegistryFactory.MICRONAUT_METRICS_BINDERS
+import static io.micronaut.configuration.metrics.micrometer.MeterRegistryFactory.MICRONAUT_METRICS_ENABLED
+import static io.micronaut.http.client.netty.HttpClientPoolMetricsRecorder.CLIENT_ALL
+import static io.micronaut.http.client.netty.HttpClientPoolMetricsRecorder.CLIENT_TAG
+import static io.micronaut.http.client.netty.HttpClientPoolMetricsRecorder.CONNECTIONS
+import static io.micronaut.http.client.netty.HttpClientPoolMetricsRecorder.CONNECTIONS_CREATED
+import static io.micronaut.http.client.netty.HttpClientPoolMetricsRecorder.CONNECTIONS_CREATE_TIME
+import static io.micronaut.http.client.netty.HttpClientPoolMetricsRecorder.STATE_OPEN
+import static io.micronaut.http.client.netty.HttpClientPoolMetricsRecorder.STATE_PENDING
+import static io.micronaut.http.client.netty.HttpClientPoolMetricsRecorder.STATE_TAG
+
+class HttpClientPoolMetricsSpec extends Specification {
+
+    @Unroll
+    void "test getting the beans #cfg #setting"() {
+        when:
+        ApplicationContext context = ApplicationContext.run([(cfg): setting])
+
+        then:
+        context.findBean(HttpClientPoolMetricsClientBinder).isPresent() == result
+        context.findBean(HttpClientPoolMetricsCustomizerBinder).isPresent() == result
+
+        cleanup:
+        context.close()
+
+        where:
+        cfg                                                        | setting | result
+        MICRONAUT_METRICS_ENABLED                                  | true    | false
+        MICRONAUT_METRICS_ENABLED                                  | false   | false
+        MICRONAUT_METRICS_BINDERS + ".web.client.pool.enabled"     | true    | true
+        MICRONAUT_METRICS_BINDERS + ".web.client.pool.enabled"     | false   | false
+    }
+
+    void "test http client pool metrics meters are present"() {
+        when:
+        EmbeddedServer embeddedServer = ApplicationContext.run(EmbeddedServer, [
+                (MICRONAUT_METRICS_BINDERS + ".web.client.pool.enabled"): true,
+                "spec.name": getClass().getSimpleName()
+        ])
+        MeterRegistry registry = embeddedServer.applicationContext.getBean(MeterRegistry)
+        DummyClient client = embeddedServer.applicationContext.getBean(DummyClient)
+
+        then:
+        client.root() == "root"
+
+        and:
+        registry.get(CONNECTIONS_CREATED).tag(CLIENT_TAG, CLIENT_ALL).counter().count() >= 1
+        registry.get(CONNECTIONS_CREATE_TIME).tag(CLIENT_TAG, CLIENT_ALL).timer().count() >= 1
+        registry.get(CONNECTIONS).tags(CLIENT_TAG, CLIENT_ALL, STATE_TAG, STATE_OPEN).gauge().value() >= 1
+        registry.get(CONNECTIONS).tags(CLIENT_TAG, CLIENT_ALL, STATE_TAG, STATE_PENDING).gauge().value() == 0
+
+        cleanup:
+        embeddedServer.close()
+    }
+
+    @Requires(property = "spec.name", value = "HttpClientPoolMetricsSpec")
+    @Client("/pool-metrics")
+    private static interface DummyClient {
+        @Get
+        String root()
+    }
+
+    @Requires(property = "spec.name", value = "HttpClientPoolMetricsSpec")
+    @Controller("/pool-metrics")
+    private static class DummyController {
+        @Get
+        String root() {
+            "root"
+        }
+    }
+}

--- a/src/main/docs/guide/metricsConcepts.adoc
+++ b/src/main/docs/guide/metricsConcepts.adoc
@@ -259,6 +259,20 @@ You can customize what metrics are exposed using `micronaut.metrics.binders.nett
 * *NettyMetricsPipelineBinder*: Instrument Netty's channel, use `micronaut.metrics.binders.netty.channels.enabled` to toggle. Default is *false*.
 The provided metrics include the channel count, current active channel count, channel error count, bytes read and written.
 
+===== HTTP Client Pool Metrics
+
+Micronaut HTTP client pool metrics can be enabled with `micronaut.metrics.binders.web.client.pool.enabled=true`.
+The provided metrics include currently open and pending client pool connections, created connection count, connection creation time, and checked out requests for `DefaultHttpClient` beans.
+
+.HTTP Client Pool Metrics provided
+|=======
+|*Name*
+| http.client.pool.connections
+| http.client.pool.connections.created
+| http.client.pool.connections.create.time
+| http.client.pool.requests
+|=======
+
 == Adding Custom Metrics
 
 To add metrics to your application, dependency-inject a `MeterRegistry` bean and use the provided methods to access counters, timers, etc.


### PR DESCRIPTION
## Summary
- add opt-in Micrometer instrumentation for Netty HTTP client pool connection lifecycle
- expose connection count, pending connection count, created connection count, connection creation time, and checked-out request gauges
- avoid recording websocket connections as HTTP pool connection attempts while preserving HTTP/1.1 and HTTP/2 pool metrics
- document the new HTTP client pool metrics binder

## Verification
- ./gradlew :micronaut-micrometer-core:compileJava :micronaut-micrometer-core:compileTestGroovy
- ./gradlew :micronaut-micrometer-core:test --tests 'io.micronaut.http.client.netty.HttpClientPoolMetricsSpec'
- ./gradlew :micronaut-micrometer-core:check
- ./gradlew docs

Resolves https://github.com/micronaut-projects/micronaut-micrometer/issues/26
