### PR TITLE
Fix Prometheus shaded protobuf dependency on 5.9.x

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,6 +11,7 @@ managed-metrics-core = '4.2.28'
 managed-micrometer = '1.13.6'
 managed-micrometer-tracing = '1.3.5'
 managed-new-relic-registry = '0.10.0'
+managed-prometheus-metrics = '1.3.3'
 managed-prometheus-metrics-exporter-pushgateway = '1.3.3'
 reflections = '0.10.2'
 
@@ -56,6 +57,11 @@ managed-micrometer-core = { module = 'io.micrometer:micrometer-core', version.re
 managed-micrometer-tracing = { module = 'io.micrometer:micrometer-tracing', version.ref = 'managed-micrometer-tracing' }
 managed-micrometer-observation = { module = 'io.micrometer:micrometer-observation', version.ref = 'managed-micrometer' }
 managed-micrometer-observation-test = { module = 'io.micrometer:micrometer-observation-test', version.ref = 'managed-micrometer' }
+managed-prometheus-metrics-config = { module = 'io.prometheus:prometheus-metrics-config', version.ref = 'managed-prometheus-metrics' }
+managed-prometheus-metrics-core = { module = 'io.prometheus:prometheus-metrics-core', version.ref = 'managed-prometheus-metrics' }
+managed-prometheus-metrics-exposition-formats = { module = 'io.prometheus:prometheus-metrics-exposition-formats', version.ref = 'managed-prometheus-metrics' }
+managed-prometheus-metrics-model = { module = 'io.prometheus:prometheus-metrics-model', version.ref = 'managed-prometheus-metrics' }
+managed-prometheus-metrics-tracer-common = { module = 'io.prometheus:prometheus-metrics-tracer-common', version.ref = 'managed-prometheus-metrics' }
 
 micrometer-registry-appoptics = { module = 'io.micrometer:micrometer-registry-appoptics', version.ref = 'managed-micrometer' }
 micrometer-registry-atlas = { module = 'io.micrometer:micrometer-registry-atlas', version.ref = 'managed-micrometer' }

--- a/micrometer-registry-prometheus/build.gradle
+++ b/micrometer-registry-prometheus/build.gradle
@@ -5,4 +5,12 @@ plugins {
 dependencies {
     api libs.micrometer.registry.prometheus
     testImplementation(mnSerde.micronaut.serde.jackson)
+
+    constraints {
+        api libs.managed.prometheus.metrics.config
+        api libs.managed.prometheus.metrics.core
+        api libs.managed.prometheus.metrics.model
+        api libs.managed.prometheus.metrics.tracer.common
+        runtimeOnly libs.managed.prometheus.metrics.exposition.formats
+    }
 }

--- a/test-suite/micronaut-serialization/build.gradle
+++ b/test-suite/micronaut-serialization/build.gradle
@@ -24,6 +24,10 @@ dependencies {
 
 graalvmNative.toolchainDetection = false
 
+tasks.withType(JavaCompile).configureEach {
+    options.release = 17
+}
+
 micronaut {
     version.set(libs.versions.micronaut.platform)
     runtime("netty")


### PR DESCRIPTION
## Summary
- manage Prometheus client Java artifacts at 1.3.3 on 5.9.x
- add Prometheus registry constraints so Micrometer 1.13.6 no longer resolves prometheus-metrics-shaded-protobuf 1.2.1

## Verification
- `JAVA_HOME=/opt/jdks/jdk21 PATH=/opt/jdks/jdk21/bin:$PATH ./gradlew --no-daemon -Porg.gradle.java.installations.auto-detect=false -Porg.gradle.java.installations.paths=/Users/nmikic/dev/multicode-workspaces/micrometer/.jdks/temurin17-local -q :micronaut-micrometer-registry-prometheus:dependencyInsight --configuration runtimeClasspath --dependency io.prometheus:prometheus-metrics-shaded-protobuf`
- `JAVA_HOME=/opt/jdks/jdk21 PATH=/opt/jdks/jdk21/bin:$PATH ./gradlew --no-daemon -Porg.gradle.java.installations.auto-detect=false -Porg.gradle.java.installations.paths=/Users/nmikic/dev/multicode-workspaces/micrometer/.jdks/temurin17-local :micronaut-micrometer-registry-prometheus:check -q`
- `JAVA_HOME=/opt/jdks/jdk21 PATH=/opt/jdks/jdk21/bin:$PATH ./gradlew --no-daemon -Porg.gradle.java.installations.auto-detect=false -Porg.gradle.java.installations.paths=/Users/nmikic/dev/multicode-workspaces/micrometer/.jdks/temurin17-local :micronaut-micrometer-bom:check -q`

Resolves #898
