### PR TITLE
fix(netty): amend inconsistent tag keys

### DIFF
--- a/micrometer-core/src/main/java/io/micronaut/configuration/metrics/binder/netty/ByteBufAllocatorMetricsBinder.java
+++ b/micrometer-core/src/main/java/io/micronaut/configuration/metrics/binder/netty/ByteBufAllocatorMetricsBinder.java
@@ -72,6 +72,7 @@ import static io.micronaut.configuration.metrics.binder.netty.NettyMetrics.SIZE;
 import static io.micronaut.configuration.metrics.binder.netty.NettyMetrics.SMALL;
 import static io.micronaut.configuration.metrics.binder.netty.NettyMetrics.SUBPAGE;
 import static io.micronaut.configuration.metrics.binder.netty.NettyMetrics.THREAD;
+import static io.micronaut.configuration.metrics.binder.netty.NettyMetrics.TOTAL;
 import static io.micronaut.configuration.metrics.binder.netty.NettyMetrics.UNPOOLED;
 import static io.micronaut.configuration.metrics.binder.netty.NettyMetrics.USAGE;
 import static io.micronaut.configuration.metrics.binder.netty.NettyMetrics.USED;
@@ -192,7 +193,7 @@ final class ByteBufAllocatorMetricsBinder {
 
         Gauge.builder(dot(NETTY, ALLOC, ARENA, ALLOCATION, COUNT), pam, PoolArenaMetric::numAllocations)
                 .description("Return the number of allocations done via the arena. This includes all sizes.")
-                .tags(tags)
+                .tags(tags.and(SIZE, TOTAL))
                 .register(meterRegistry);
         Gauge.builder(dot(NETTY, ALLOC, ARENA, ALLOCATION, COUNT), pam, PoolArenaMetric::numSmallAllocations)
                 .description("Return the number of small allocations done via the arena.")
@@ -209,7 +210,7 @@ final class ByteBufAllocatorMetricsBinder {
 
         Gauge.builder(dot(NETTY, ALLOC, ARENA, DEALLOCATION, COUNT), pam, PoolArenaMetric::numDeallocations)
                 .description("Return the number of deallocations done via the arena. This includes all sizes.")
-                .tags(tags)
+                .tags(tags.and(SIZE, TOTAL))
                 .register(meterRegistry);
         Gauge.builder(dot(NETTY, ALLOC, ARENA, DEALLOCATION, COUNT), pam, PoolArenaMetric::numSmallDeallocations)
                 .description("Return the number of small deallocations done via the arena.")
@@ -226,7 +227,7 @@ final class ByteBufAllocatorMetricsBinder {
 
         Gauge.builder(dot(NETTY, ALLOC, ARENA, ALLOCATION, ACTIVE, COUNT), pam, PoolArenaMetric::numActiveAllocations)
                 .description("Return the number of currently active allocations.")
-                .tags(tags)
+                .tags(tags.and(SIZE, TOTAL))
                 .register(meterRegistry);
         Gauge.builder(dot(NETTY, ALLOC, ARENA, ALLOCATION, ACTIVE, COUNT), pam, PoolArenaMetric::numActiveSmallAllocations)
                 .description("Return the number of currently active small allocations.")

--- a/micrometer-core/src/main/java/io/micronaut/configuration/metrics/binder/netty/NettyMetrics.java
+++ b/micrometer-core/src/main/java/io/micronaut/configuration/metrics/binder/netty/NettyMetrics.java
@@ -46,6 +46,7 @@ final class NettyMetrics {
     static final String SMALL = "small";
     static final String NORMAL = "normal";
     static final String HUGE = "huge";
+    static final String TOTAL = "total";
 
     static final String SUBPAGE = "subpage";
     static final String CHUNKLIST = "chunklist";

--- a/micrometer-core/src/test/groovy/io/micronaut/configuration/metrics/binder/netty/MicronautNettyByteBufAllocatorMetricsBinderSpec.groovy
+++ b/micrometer-core/src/test/groovy/io/micronaut/configuration/metrics/binder/netty/MicronautNettyByteBufAllocatorMetricsBinderSpec.groovy
@@ -1,6 +1,7 @@
 package io.micronaut.configuration.metrics.binder.netty
 
 import io.micrometer.core.instrument.Gauge
+import io.micrometer.core.instrument.Meter
 import io.micrometer.core.instrument.MeterRegistry
 import io.micrometer.core.instrument.Tags
 import io.micrometer.core.instrument.search.RequiredSearch
@@ -15,11 +16,17 @@ import spock.util.concurrent.PollingConditions
 
 import static io.micronaut.configuration.metrics.binder.netty.ByteBufAllocatorMetricsConfig.ByteBufAllocatorMetricKind.POOLED_ALLOCATOR
 import static io.micronaut.configuration.metrics.binder.netty.ByteBufAllocatorMetricsConfig.ByteBufAllocatorMetricKind.UNPOOLED_ALLOCATOR
+import static io.micronaut.configuration.metrics.binder.netty.NettyMetrics.ACTIVE
 import static io.micronaut.configuration.metrics.binder.netty.NettyMetrics.ALLOC
+import static io.micronaut.configuration.metrics.binder.netty.NettyMetrics.ALLOCATION
+import static io.micronaut.configuration.metrics.binder.netty.NettyMetrics.ARENA
+import static io.micronaut.configuration.metrics.binder.netty.NettyMetrics.COUNT
+import static io.micronaut.configuration.metrics.binder.netty.NettyMetrics.DEALLOCATION
 import static io.micronaut.configuration.metrics.binder.netty.NettyMetrics.DIRECT
 import static io.micronaut.configuration.metrics.binder.netty.NettyMetrics.MEMORY
 import static io.micronaut.configuration.metrics.binder.netty.NettyMetrics.NETTY
 import static io.micronaut.configuration.metrics.binder.netty.NettyMetrics.POOLED
+import static io.micronaut.configuration.metrics.binder.netty.NettyMetrics.SIZE
 import static io.micronaut.configuration.metrics.binder.netty.NettyMetrics.USED
 import static io.micronaut.configuration.metrics.binder.netty.NettyMetrics.dot
 import static io.micronaut.configuration.metrics.micrometer.MeterRegistryFactory.MICRONAUT_METRICS_BINDERS
@@ -139,6 +146,32 @@ class MicronautNettyByteBufAllocatorMetricsBinderSpec extends Specification {
 
         cleanup:
         context.close()
+    }
+
+    @Unroll
+    void "test ByteBufAllocator metrics pooled arena counter meters share consistent tag keys for #name"() {
+        when:
+        ApplicationContext context = ApplicationContext.run(
+                [MICRONAUT_METRICS_ENABLED                                        : true,
+                 (MICRONAUT_METRICS_BINDERS + ".netty.bytebuf-allocators.enabled"): true]
+        )
+        MeterRegistry registry = context.getBean(MeterRegistry)
+        Collection<Meter> meters = registry.find(name).meters()
+        Set<Set<String>> distinctTagKeySets = meters.collect { Meter m -> m.id.tags.collect { it.key } as Set } as Set
+        Set<String> sizeValues = meters.collect { Meter m -> m.id.getTag(SIZE) } as Set
+
+        then:
+        !meters.isEmpty()
+        distinctTagKeySets.size() == 1
+        sizeValues == ['total', 'small', 'normal', 'huge'] as Set
+
+        cleanup:
+        context.close()
+
+        where:
+        name << [dot(NETTY, ALLOC, ARENA, ALLOCATION, COUNT),
+                 dot(NETTY, ALLOC, ARENA, DEALLOCATION, COUNT),
+                 dot(NETTY, ALLOC, ARENA, ALLOCATION, ACTIVE, COUNT)]
     }
 
     @Client('/bytebufallocatortest')


### PR DESCRIPTION
`ByteBufAllocatorMetricsBinder` registered the total for `netty.alloc.arena.{allocation,deallocation,allocation.active}.count` without a `size` tag, while the per-size variants (`small`/`normal`/`huge`) shared the same metric name with an extra `size` tag. Prometheus rejects same-named meters with mismatched tag-key sets, so the breakdown gauges failed to register.

Limitation is documented at [docs.micrometer.io](https://docs.micrometer.io/micrometer/reference/implementations/prometheus.html?utm_source=chatgpt.com#_limitation_on_same_name_with_different_set_of_tag_keys).

Tag the totals with `size=total` so all meters in each group share the same tag-key set.

---

Note: the totals gauge tag set changes from `{memory, arena.number}` to `{memory, arena.number, size=total}`. Queries that filtered by absence of `size` to retrieve totals must now select `size="total"`.