### PR TITLE
Use RouteAttributes for HTTP metrics routes

### DIFF
--- a/micrometer-core/src/main/java/io/micronaut/configuration/metrics/binder/web/ServerMetricsFilter.java
+++ b/micrometer-core/src/main/java/io/micronaut/configuration/metrics/binder/web/ServerMetricsFilter.java
@@ -23,13 +23,14 @@ import io.micronaut.context.annotation.Requires;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.order.Ordered;
 import io.micronaut.core.util.SupplierUtil;
-import io.micronaut.http.HttpAttributes;
+import io.micronaut.http.BasicHttpAttributes;
 import io.micronaut.http.HttpRequest;
 import io.micronaut.http.HttpResponse;
 import io.micronaut.http.annotation.RequestFilter;
 import io.micronaut.http.annotation.ResponseFilter;
 import io.micronaut.http.annotation.ServerFilter;
 import io.micronaut.http.filter.ServerFilterPhase;
+import io.micronaut.web.router.RouteAttributes;
 import io.micronaut.web.router.UriRouteMatch;
 import jakarta.inject.Provider;
 
@@ -75,9 +76,11 @@ final class ServerMetricsFilter implements Ordered {
     }
 
     private String resolvePath(HttpRequest<?> request) {
-        Optional<String> routeInfo = request.getAttribute(HttpAttributes.ROUTE_INFO, UriRouteMatch.class)
+        Optional<String> routeInfo = RouteAttributes.getRouteMatch(request)
+            .filter(UriRouteMatch.class::isInstance)
+            .map(UriRouteMatch.class::cast)
             .map(match -> match.getRouteInfo().getUriMatchTemplate().toPathString());
-        return routeInfo.orElseGet(() -> request.getAttribute(HttpAttributes.URI_TEMPLATE, String.class)
+        return routeInfo.orElseGet(() -> BasicHttpAttributes.getUriTemplate(request)
             .orElse(UNMATCHED_URI));
     }
 

--- a/micrometer-core/src/main/java/io/micronaut/configuration/metrics/binder/web/ServerRequestMeterRegistryFilter.java
+++ b/micrometer-core/src/main/java/io/micronaut/configuration/metrics/binder/web/ServerRequestMeterRegistryFilter.java
@@ -17,13 +17,12 @@ package io.micronaut.configuration.metrics.binder.web;
 
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micronaut.context.annotation.Value;
-import io.micronaut.http.HttpAttributes;
+import io.micronaut.http.BasicHttpAttributes;
 import io.micronaut.http.HttpRequest;
 import io.micronaut.http.MutableHttpResponse;
 import io.micronaut.http.filter.HttpServerFilter;
 import io.micronaut.http.filter.ServerFilterChain;
-import io.micronaut.http.uri.UriMatchTemplate;
-import io.micronaut.web.router.UriRouteInfo;
+import io.micronaut.web.router.RouteAttributes;
 import io.micronaut.web.router.UriRouteMatch;
 import jakarta.inject.Provider;
 import org.reactivestreams.Publisher;
@@ -58,11 +57,11 @@ public class ServerRequestMeterRegistryFilter implements HttpServerFilter {
     }
 
     private String resolvePath(HttpRequest<?> request) {
-        Optional<String> routeInfo = request.getAttribute(HttpAttributes.ROUTE_INFO, UriRouteMatch.class)
-            .map(UriRouteMatch::getRouteInfo)
-            .map(UriRouteInfo::getUriMatchTemplate)
-            .map(UriMatchTemplate::toPathString);
-        return routeInfo.orElseGet(() -> request.getAttribute(HttpAttributes.URI_TEMPLATE, String.class)
+        Optional<String> routeInfo = RouteAttributes.getRouteMatch(request)
+            .filter(UriRouteMatch.class::isInstance)
+            .map(UriRouteMatch.class::cast)
+            .map(match -> match.getRouteInfo().getUriMatchTemplate().toPathString());
+        return routeInfo.orElseGet(() -> BasicHttpAttributes.getUriTemplate(request)
                         .orElse(UNMATCHED_URI));
     }
 

--- a/micrometer-core/src/test/groovy/io/micronaut/configuration/metrics/binder/web/HttpMetricsSpec.groovy
+++ b/micrometer-core/src/test/groovy/io/micronaut/configuration/metrics/binder/web/HttpMetricsSpec.groovy
@@ -34,7 +34,6 @@ import io.micronaut.websocket.WebSocketSession
 import io.micronaut.websocket.annotation.*
 import org.reactivestreams.Publisher
 import reactor.core.publisher.Flux
-import spock.lang.PendingFeature
 import spock.lang.Specification
 
 import jakarta.validation.constraints.NotBlank
@@ -282,7 +281,6 @@ class HttpMetricsSpec extends Specification {
         context.close()
     }
 
-    @PendingFeature
     void "test websocket"() {
         when:
         EmbeddedServer embeddedServer = ApplicationContext.run(EmbeddedServer, [

--- a/micrometer-observation-http/src/main/java/io/micronaut/micrometer/observation/http/server/instrumentation/DefaultServerRequestObservationConvention.java
+++ b/micrometer-observation-http/src/main/java/io/micronaut/micrometer/observation/http/server/instrumentation/DefaultServerRequestObservationConvention.java
@@ -19,10 +19,11 @@ import io.micrometer.common.KeyValue;
 import io.micrometer.common.KeyValues;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.util.StringUtils;
-import io.micronaut.http.HttpAttributes;
+import io.micronaut.http.BasicHttpAttributes;
 import io.micronaut.http.HttpRequest;
 import io.micronaut.http.HttpStatus;
 import io.micronaut.http.uri.UriMatchTemplate;
+import io.micronaut.web.router.RouteAttributes;
 import io.micronaut.web.router.UriRouteInfo;
 
 import java.util.Optional;
@@ -78,16 +79,12 @@ public final class DefaultServerRequestObservationConvention implements ServerRe
     }
 
     private String getRoute(HttpRequest<?> request) {
-        Optional<String> routeInfo = request.getAttribute(HttpAttributes.ROUTE_INFO)
+        Optional<String> routeInfo = RouteAttributes.getRouteInfo(request)
             .filter(UriRouteInfo.class::isInstance)
             .map(ri -> (UriRouteInfo<?, ?>) ri)
             .map(UriRouteInfo::getUriMatchTemplate)
             .map(UriMatchTemplate::toPathString);
-        return routeInfo.orElseGet(() ->
-            request.getAttribute(HttpAttributes.URI_TEMPLATE)
-                .map(Object::toString)
-                .orElse(null)
-        );
+        return routeInfo.orElseGet(() -> BasicHttpAttributes.getUriTemplate(request).orElse(null));
     }
 
     @Override


### PR DESCRIPTION
Resolve route templates through RouteAttributes and BasicHttpAttributes, and enable the websocket metrics spec.