### PR TITLE
Fix loom carrier executor metrics binding

### DIFF
--- a/micrometer-core/src/main/java/io/micronaut/configuration/metrics/binder/executor/ExecutorServiceMetricsBinder.java
+++ b/micrometer-core/src/main/java/io/micronaut/configuration/metrics/binder/executor/ExecutorServiceMetricsBinder.java
@@ -53,12 +53,16 @@ public class ExecutorServiceMetricsBinder implements BeanCreatedEventListener<Ex
     private static final String THREAD_PER_TASK_EXECUTOR = "java.util.concurrent.ThreadPerTaskExecutor";
 
     private final BeanProvider<MeterRegistry> meterRegistryProvider;
+    private final List<ExecutorServiceMetricsContributor> metricsContributors;
 
     /**
      * @param meterRegistryProvider The meter registry provider
+     * @param metricsContributors The executor metrics contributors
      */
-    public ExecutorServiceMetricsBinder(BeanProvider<MeterRegistry> meterRegistryProvider) {
+    public ExecutorServiceMetricsBinder(BeanProvider<MeterRegistry> meterRegistryProvider,
+                                        List<ExecutorServiceMetricsContributor> metricsContributors) {
         this.meterRegistryProvider = meterRegistryProvider;
+        this.metricsContributors = metricsContributors;
     }
 
     @Override
@@ -69,10 +73,6 @@ public class ExecutorServiceMetricsBinder implements BeanCreatedEventListener<Ex
         while (unwrapped instanceof InstrumentedExecutorService) {
             unwrapped = ((InstrumentedExecutorService) unwrapped).getTarget();
         }
-        // Netty EventLoopGroups require separate instrumentation.
-        if (unwrapped.getClass().getName().startsWith("io.netty")) {
-            return unwrapped;
-        }
         // ExecutorServiceMetrics does not provide metrics for virtual threads
         if (unwrapped.getClass().getName().equals(THREAD_PER_TASK_EXECUTOR)) {
             return executorService;
@@ -82,6 +82,12 @@ public class ExecutorServiceMetricsBinder implements BeanCreatedEventListener<Ex
         BeanIdentifier beanIdentifier = event.getBeanIdentifier();
 
         List<Tag> tags = Collections.emptyList(); // allow tags?
+
+        for (ExecutorServiceMetricsContributor metricsContributor : metricsContributors) {
+            if (metricsContributor.supports(unwrapped)) {
+                return metricsContributor.bindTo(meterRegistry, unwrapped, beanIdentifier.getName(), tags);
+            }
+        }
 
         // bind the service metrics
         new ExecutorServiceMetrics(unwrapped, beanIdentifier.getName(), tags).bindTo(meterRegistry);

--- a/micrometer-core/src/main/java/io/micronaut/configuration/metrics/binder/executor/ExecutorServiceMetricsContributor.java
+++ b/micrometer-core/src/main/java/io/micronaut/configuration/metrics/binder/executor/ExecutorServiceMetricsContributor.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.configuration.metrics.binder.executor;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
+import io.micronaut.core.annotation.Internal;
+
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+
+/**
+ * Contributes metrics for executor service implementations that need custom binding.
+ *
+ * @since 6.0.0
+ */
+@Internal
+public interface ExecutorServiceMetricsContributor {
+
+    /**
+     * @param executorService The executor service
+     * @return Whether this contributor handles the executor service
+     */
+    boolean supports(ExecutorService executorService);
+
+    /**
+     * Bind metrics for the executor service.
+     *
+     * @param meterRegistry The meter registry
+     * @param executorService The executor service
+     * @param name The bean name
+     * @param tags The tags
+     * @return The executor service bean to keep
+     */
+    ExecutorService bindTo(MeterRegistry meterRegistry, ExecutorService executorService, String name, List<Tag> tags);
+}

--- a/micrometer-core/src/main/java/io/micronaut/configuration/metrics/binder/netty/NettyEventLoopGroupMetricsContributor.java
+++ b/micrometer-core/src/main/java/io/micronaut/configuration/metrics/binder/netty/NettyEventLoopGroupMetricsContributor.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.configuration.metrics.binder.netty;
+
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.Tags;
+import io.micronaut.configuration.metrics.binder.executor.ExecutorServiceMetricsContributor;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.core.annotation.Internal;
+import io.netty.channel.EventLoopGroup;
+import io.netty.util.concurrent.EventExecutor;
+import io.netty.util.concurrent.SingleThreadEventExecutor;
+import jakarta.inject.Singleton;
+
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+
+/**
+ * Binds executor-style gauges for Netty event loop groups.
+ *
+ * @since 6.0.0
+ */
+@Singleton
+@Requires(classes = EventLoopGroup.class)
+@Internal
+final class NettyEventLoopGroupMetricsContributor implements ExecutorServiceMetricsContributor {
+
+    @Override
+    public boolean supports(ExecutorService executorService) {
+        return executorService instanceof EventLoopGroup;
+    }
+
+    @Override
+    public ExecutorService bindTo(MeterRegistry meterRegistry, ExecutorService executorService, String name, List<Tag> tags) {
+        EventLoopGroup eventLoopGroup = (EventLoopGroup) executorService;
+        Iterable<Tag> meterTags = Tags.concat(tags, "name", name);
+        Gauge.builder("executor.queued", eventLoopGroup, NettyEventLoopGroupMetricsContributor::pendingTasks)
+                .tags(meterTags)
+                .description("The approximate number of tasks that are queued for execution.")
+                .register(meterRegistry);
+        Gauge.builder("executor.pool.size", eventLoopGroup, NettyEventLoopGroupMetricsContributor::poolSize)
+                .tags(meterTags)
+                .description("The current number of threads in the pool.")
+                .baseUnit("threads")
+                .register(meterRegistry);
+        return executorService;
+    }
+
+    private static double pendingTasks(EventLoopGroup eventLoopGroup) {
+        int pendingTasks = 0;
+        for (EventExecutor eventExecutor : eventLoopGroup) {
+            if (eventExecutor instanceof SingleThreadEventExecutor singleThreadEventExecutor) {
+                pendingTasks += singleThreadEventExecutor.pendingTasks();
+            }
+        }
+        return pendingTasks;
+    }
+
+    private static double poolSize(EventLoopGroup eventLoopGroup) {
+        int poolSize = 0;
+        for (EventExecutor ignored : eventLoopGroup) {
+            poolSize++;
+        }
+        return poolSize;
+    }
+}

--- a/micrometer-core/src/test/groovy/io/micronaut/configuration/metrics/binder/executor/ExecutorServiceMetricsBinderSpec.groovy
+++ b/micrometer-core/src/test/groovy/io/micronaut/configuration/metrics/binder/executor/ExecutorServiceMetricsBinderSpec.groovy
@@ -79,6 +79,19 @@ class ExecutorServiceMetricsBinderSpec extends Specification {
         context.close()
     }
 
+    @Issue("https://github.com/micronaut-projects/micronaut-micrometer/issues/1186")
+    void "test loom carrier event loop group not instrumented"() {
+        when:
+        ApplicationContext context = ApplicationContext.run()
+        EventLoopGroup eventLoopGroup = context.getBean(EventLoopGroup, Qualifiers.byName("loom-carrier"))
+
+        then:
+        eventLoopGroup instanceof TestEventLoopGroup
+
+        cleanup:
+        context.close()
+    }
+
     @Issue("https://github.com/micronaut-projects/micronaut-micrometer/issues/679")
     void "test the virtual task executor is unbound with no warnings logged"() {
         when:
@@ -126,8 +139,17 @@ class ExecutorServiceMetricsBinderSpec extends Specification {
         @Named("test")
         @Requires(sdk = Requires.Sdk.MICRONAUT, version = "2.0.0")
         EventLoopGroup eventLoopGroup() {
-            return new DefaultEventLoop()
+            return new TestEventLoopGroup()
         }
+
+        @Singleton
+        @Named("loom-carrier")
+        TestEventLoopGroup loomCarrierEventLoopGroup() {
+            return new TestEventLoopGroup()
+        }
+    }
+
+    static class TestEventLoopGroup extends DefaultEventLoop {
     }
 
     class SimpleStreamsListener implements IStandardStreamsListener {


### PR DESCRIPTION
Fixes #1186.

Netty event-loop implementations are now delegated to an optional Netty-specific executor metrics contributor, so LoomCarrierGroup is returned as an EventLoopGroup instead of being wrapped by the generic binder.

Test: `./gradlew :micronaut-micrometer-core:test --tests 'io.micronaut.configuration.metrics.binder.executor.ExecutorServiceMetricsBinderSpec'`