### PR TITLE
Fix duplicate http.server/client.requests when observation HTTP metrics enabled

### DIFF
--- a/micrometer-core/src/main/java/io/micronaut/configuration/metrics/binder/web/WebMetricsClientCondition.java
+++ b/micrometer-core/src/main/java/io/micronaut/configuration/metrics/binder/web/WebMetricsClientCondition.java
@@ -31,7 +31,7 @@ public class WebMetricsClientCondition implements Condition {
             return false;
         }
 
-        return !context.containsProperty("micrometer.observation.client.server.enabled") || !context.getProperty("micrometer.observation.http.client.enabled", Boolean.class).orElse(false);
+        return !isClassPresent || !context.getProperty("micrometer.observation.http.client.enabled", Boolean.class).orElse(false);
     }
 
 }

--- a/micrometer-core/src/main/java/io/micronaut/configuration/metrics/binder/web/WebMetricsServerCondition.java
+++ b/micrometer-core/src/main/java/io/micronaut/configuration/metrics/binder/web/WebMetricsServerCondition.java
@@ -31,6 +31,6 @@ public class WebMetricsServerCondition implements Condition {
             return false;
         }
 
-        return !context.containsProperty("micrometer.observation.server.server.enabled") || !context.getProperty("micrometer.observation.http.server.enabled", Boolean.class).orElse(false);
+        return !isClassPresent || !context.getProperty("micrometer.observation.http.server.enabled", Boolean.class).orElse(false);
     }
 }

--- a/micrometer-observation-http/src/test/groovy/io/micronaut/micrometer/observation/FilterCreationSpec.groovy
+++ b/micrometer-observation-http/src/test/groovy/io/micronaut/micrometer/observation/FilterCreationSpec.groovy
@@ -23,6 +23,32 @@ class FilterCreationSpec extends Specification{
         context.getBeansOfType(ServerMetricsFilter).size() == 0
     }
 
+    void 'if micrometer observation server filter is explicitly enabled do not also create web server metrics'() {
+        when:
+        def context = io.micronaut.context.ApplicationContext.builder(
+                'micronaut.application.name': 'test-app',
+                'micrometer.observation.http.server.enabled': true
+        ).start()
+
+        then:
+        context.getBeansOfType(MeterRegistry).size() == 1
+        context.getBeansOfType(ObservationServerFilter).size() == 1
+        context.getBeansOfType(ServerMetricsFilter).size() == 0
+    }
+
+    void 'if micrometer observation client filter is explicitly enabled do not also create web client metrics'() {
+        when:
+        def context = io.micronaut.context.ApplicationContext.builder(
+                'micronaut.application.name': 'test-app',
+                'micrometer.observation.http.client.enabled': true
+        ).start()
+
+        then:
+        context.getBeansOfType(MeterRegistry).size() == 1
+        context.getBeansOfType(ObservationClientFilter).size() == 1
+        context.getBeansOfType(ClientMetricsFilter).size() == 0
+    }
+
     void 'if micrometer observation client filter is disabled enable web client metrics by default'() {
         when:
         def context = io.micronaut.context.ApplicationContext.builder(


### PR DESCRIPTION
## Problem

When the Micronaut Observation HTTP module (`micronaut-micrometer-observation-http`) is on the classpath and enabled, `http.server.requests` and `http.client.requests` are recorded **twice** per request — once by the observation filter and once by the legacy web metrics filter. The two series carry different tag sets (the observation series is a superset, adding e.g. `error`, plus long-task timers and trace correlation), so the duplication is easy to miss until it inflates cardinality and downstream metric counts.

## Root cause

`WebMetricsServerCondition` and `WebMetricsClientCondition` decide whether the legacy filters (`ServerMetricsFilter` / `ClientMetricsFilter`) should be created. They are meant to back off when the observation filter is present and enabled.

The final `return` referenced a property that does not exist, due to a typo with a doubled segment:

- `micrometer.observation.server.server.enabled` (should relate to the server class presence)
- `micrometer.observation.client.server.enabled` (should relate to the client class presence)

`containsProperty(...)` on a non-existent key is always `false`, so `!containsProperty(...)` is always `true` and the `||` short-circuits to `true`. The legacy filter is therefore created even when the observation filter is active → duplicate meters.

This typo is present on `6.1.x` and `master`, and in released 5.x lines.

## Fix

Replace the phantom-property check with the already-computed `isClassPresent` flag, which is the intended guard:

```java
return !isClassPresent || !context.getProperty("micrometer.observation.http.server.enabled", Boolean.class).orElse(false);
```

Semantics after the fix — create the legacy filter only when the observation filter is **absent**, or when it is present but **explicitly disabled**. Using `isClassPresent` (rather than the `http.*.enabled` property) also preserves legacy metrics for applications that set `micrometer.observation.http.*.enabled` without the observation module on the classpath.

Behaviour matrix (server; client is symmetric):

| observation module present | `observation.http.server.enabled` | legacy `ServerMetricsFilter` |
|---|---|---|
| yes | unset (default on) | not created |
| yes | `true`  | not created ✅ (was **created** before — the bug) |
| yes | `false` | created |
| no  | any | created |

## Tests

Added two cases to `micrometer-observation-http` `FilterCreationSpec` for the previously-untested **explicitly enabled** configuration (`micrometer.observation.http.{server,client}.enabled: true`) — precisely the setup that triggered the duplicate. They assert that only the observation filter is created and the legacy filter is absent. The existing default / `false` / both-disabled cases continue to pass.
