### PR TITLE
Fix duplicate http.server/client.requests when observation HTTP metrics enabled (5.13.x)

### DIFF
--- a/micrometer-core/src/main/java/io/micronaut/configuration/metrics/binder/web/WebMetricsClientCondition.java
+++ b/micrometer-core/src/main/java/io/micronaut/configuration/metrics/binder/web/WebMetricsClientCondition.java
@@ -31,7 +31,7 @@ public class WebMetricsClientCondition implements Condition {
             return false;
         }
 
-        return !context.containsProperty("micrometer.observation.client.server.enabled") || !context.getProperty("micrometer.observation.http.client.enabled", Boolean.class).orElse(false);
+        return !isClassPresent || !context.getProperty("micrometer.observation.http.client.enabled", Boolean.class).orElse(false);
     }
 
 }

--- a/micrometer-core/src/main/java/io/micronaut/configuration/metrics/binder/web/WebMetricsServerCondition.java
+++ b/micrometer-core/src/main/java/io/micronaut/configuration/metrics/binder/web/WebMetricsServerCondition.java
@@ -31,6 +31,6 @@ public class WebMetricsServerCondition implements Condition {
             return false;
         }
 
-        return !context.containsProperty("micrometer.observation.server.server.enabled") || !context.getProperty("micrometer.observation.http.server.enabled", Boolean.class).orElse(false);
+        return !isClassPresent || !context.getProperty("micrometer.observation.http.server.enabled", Boolean.class).orElse(false);
     }
 }

--- a/micrometer-observation-http/src/test/groovy/io/micronaut/micrometer/observation/FilterCreationSpec.groovy
+++ b/micrometer-observation-http/src/test/groovy/io/micronaut/micrometer/observation/FilterCreationSpec.groovy
@@ -23,6 +23,32 @@ class FilterCreationSpec extends Specification{
         context.getBeansOfType(ServerMetricsFilter).size() == 0
     }
 
+    void 'if micrometer observation server filter is explicitly enabled do not also create web server metrics'() {
+        when:
+        def context = io.micronaut.context.ApplicationContext.builder(
+                'micronaut.application.name': 'test-app',
+                'micrometer.observation.http.server.enabled': true
+        ).start()
+
+        then:
+        context.getBeansOfType(MeterRegistry).size() == 1
+        context.getBeansOfType(ObservationServerFilter).size() == 1
+        context.getBeansOfType(ServerMetricsFilter).size() == 0
+    }
+
+    void 'if micrometer observation client filter is explicitly enabled do not also create web client metrics'() {
+        when:
+        def context = io.micronaut.context.ApplicationContext.builder(
+                'micronaut.application.name': 'test-app',
+                'micrometer.observation.http.client.enabled': true
+        ).start()
+
+        then:
+        context.getBeansOfType(MeterRegistry).size() == 1
+        context.getBeansOfType(ObservationClientFilter).size() == 1
+        context.getBeansOfType(ClientMetricsFilter).size() == 0
+    }
+
     void 'if micrometer observation client filter is disabled enable web client metrics by default'() {
         when:
         def context = io.micronaut.context.ApplicationContext.builder(


### PR DESCRIPTION
Backport target: `5.13.x`. Same fix as #1223 (which targets 6.1.x), raised against the still-maintained 5.13.x line so it can ship as a 5.13.4 patch and forward-merge to 6.0.x/6.1.x.

## Problem
`WebMetricsServerCondition` / `WebMetricsClientCondition` gate the legacy web metrics filters (`ServerMetricsFilter` / `ClientMetricsFilter`) and are meant to back off when the observation HTTP filters are present and enabled, so each request is timed once.

The final return references a property that does not exist — `micrometer.observation.server.server.enabled` / `...client.server.enabled` (doubled segment). `containsProperty` on a non-existent key is always false, so the negation is always true and the `||` short-circuits to true: the legacy filter is created even when the observation filter is active. Result: two meters per request with different tag sets (the observation series is a superset) — duplicated `http.server.requests` / `http.client.requests`.

## Fix
Replace the phantom-property check with the already-computed `isClassPresent` flag (the intended guard): create the legacy filter only when the observation filter is absent, or present but explicitly disabled. Using `isClassPresent` (rather than the `http.*.enabled` property) preserves legacy metrics for apps that set the property without the observation module on the classpath.

## Tests
Adds regression tests in `FilterCreationSpec` for the previously-untested *explicitly enabled* case — exactly the configuration that triggered the duplicate.

## Relationship to existing PRs
- Duplicate/competing: #1054 (same intent, 5.13.x) — this PR adds the regression tests and the minimal `isClassPresent` fix.
- #1223 is the identical fix targeting 6.1.x. Once this lands on 5.13.x and is forward-merged up, #1223 can be closed.

## Request
Please consider releasing this as **5.13.4** — downstream consumers are pinned to 5.13.3 and hit the duplicate metrics on that line.